### PR TITLE
Pr/feature/pixhawk min delay

### DIFF
--- a/src/Control/UAV/Ardupilot/Task.cpp
+++ b/src/Control/UAV/Ardupilot/Task.cpp
@@ -445,6 +445,7 @@ namespace Control
           {
             m_TCP_sock = new TCPSocket;
             m_TCP_sock->connect(m_args.TCP_addr, m_args.TCP_port);
+            m_TCP_sock->setNoDelay(true);
             setupRate(m_args.trate);
             inf(DTR("Ardupilot interface initialized"));
           }
@@ -1525,6 +1526,8 @@ namespace Control
           m_estate.p = att.rollspeed;
           m_estate.q = att.pitchspeed;
           m_estate.r = att.yawspeed;
+
+          dispatch(m_estate);
         }
 
         void
@@ -1617,7 +1620,7 @@ namespace Control
           m_estate.depth = -1;
           m_estate.alt = -1;
 
-          dispatch(m_estate);
+
         }
 
         float

--- a/src/Transports/SerialOverTCP/Task.cpp
+++ b/src/Transports/SerialOverTCP/Task.cpp
@@ -125,6 +125,7 @@ namespace Transports
       {
         m_sock->bind(m_args.tcp_port);
         m_sock->listen(1024);
+        m_sock->setNoDelay(true);
         m_poll.add(*m_sock);
         m_poll.add(*m_uart);
       }


### PR DESCRIPTION
This PR shortens the delay between pixhawk and beaglebone black by as much as 100 ms. PR opened to start discussion, and for me and @jffortuna  to work on this. 

Possible improvements: Add parameter to SerialOverTCP to enable/disable NoDelay mode. 

In the future, the serial connection should be used in the ardupilot task directly. 

