### PR TITLE
cmake/Libraries/Phidget: Added support for Phidget

### DIFF
--- a/cmake/Libraries/Phidget.cmake
+++ b/cmake/Libraries/Phidget.cmake
@@ -1,0 +1,37 @@
+############################################################################
+# Copyright 2007-2015 Universidade do Porto - Faculdade de Engenharia      #
+# Laboratório de Sistemas e Tecnologia Subaquática (LSTS)                  #
+############################################################################
+# This file is part of DUNE: Unified Navigation Environment.               #
+#                                                                          #
+# Commercial Licence Usage                                                 #
+# Licencees holding valid commercial DUNE licences may use this file in    #
+# accordance with the commercial licence agreement provided with the       #
+# Software or, alternatively, in accordance with the terms contained in a  #
+# written agreement between you and Universidade do Porto. For licensing   #
+# terms, conditions, and further information contact lsts@fe.up.pt.        #
+#                                                                          #
+# European Union Public Licence - EUPL v.1.1 Usage                         #
+# Alternatively, this file may be used under the terms of the EUPL,        #
+# Version 1.1 only (the "Licence"), appearing in the file LICENCE.md       #
+# included in the packaging of this file. You may not use this work        #
+# except in compliance with the Licence. Unless required by applicable     #
+# law or agreed to in writing, software distributed under the Licence is   #
+# distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF     #
+# ANY KIND, either express or implied. See the Licence for the specific    #
+# language governing permissions and limitations at                        #
+# http://ec.europa.eu/idabc/eupl.html.                                     #
+############################################################################
+# Author: Kristian Klausen                                                 #
+############################################################################
+
+dune_test_lib(phidget21 CPhidgetBridge_setEnabled)
+dune_test_header("phidget21.h")
+
+if(DUNE_SYS_HAS_LIB_PHIDGET21 AND DUNE_SYS_HAS_PHIDGET21_H)
+  set(DUNE_SYS_HAS_PHIDGET 1 CACHE INTERNAL "PHIDGET library")
+  set(DUNE_USING_PHIDGET 1 CACHE INTERNAL "PHIDGET library")
+else(DUNE_SYS_HAS_LIB_PHIDGET21 AND DUNE_SYS_HAS_PHIDGET21_H)
+  set(DUNE_SYS_HAS_PHIDGET 0 CACHE INTERNAL "PHIDGET library")
+  set(DUNE_USING_PHIDGET 0 CACHE INTERNAL "PHIDGET library")
+endif(DUNE_SYS_HAS_LIB_PHIDGET21 AND DUNE_SYS_HAS_PHIDGET21_H)


### PR DESCRIPTION
Phidget is a USB-based sensor board, useful for fast-prototype sensor applications. 
(With some minor changes to Glued, it works and is tested on the beaglebone. This PR will come later. )