### PR TITLE
WIP - Adding option for filtering based on Entity in ProxyPathController

### DIFF
--- a/src/DUNE/Control/ProxyPathController.cpp
+++ b/src/DUNE/Control/ProxyPathController.cpp
@@ -41,8 +41,8 @@ namespace DUNE
     {
       param("EstimatedState Filter", m_state_src)
       .defaultValue("self")
-      .description("List of <System>+<System> that defines the source"
-                   " systems allowed to pass EstimatedState messages");
+      .description("List of <System>+<System> OR <Entity>+<Entity> that defines the source"
+                   " systems or entities allowed to pass EstimatedState messages");
     }
 
     ProxyPathController::~ProxyPathController(void)
@@ -55,8 +55,17 @@ namespace DUNE
     {
       PathController::onEntityResolution();
 
-      // Process the systems allowed to pass the EstimatedState
-      m_state_filter = new SourceFilter(*this, true, m_state_src, "EstimatedState");
+      // Check if first input is a Entity
+      if (m_state_src.size() > 0 && m_ctx.entities.labelExists(m_state_src[0]))
+      {
+        // Set up an Entity filter
+        m_state_filter = new SourceFilter(*this, false, m_state_src, "EstimatedState");
+      }
+      else
+      {
+        // Process the systems allowed to pass the EstimatedState
+        m_state_filter = new SourceFilter(*this, true, m_state_src, "EstimatedState");
+      }
     }
 
     bool


### PR DESCRIPTION
For discussion. 

I would like to extend ProxyPathController to be able to filter by Entity, not just System. Available options: 

1: New class EntityProxyPathController, with same functionality but different filter. 
2: New parameter in ProxyPathController, wich sets the filter (System, Entity, System+Entity)
3: Parse the current list and identify if it's a system or entity

Nr 3 is quickly illustrated in the below commit, which would be a quite user-friendly method IMO. 

Any opinions on best approach?