### PR TITLE
Control/Ardupilot: Proper handling of ArduCopter Height

### DIFF
--- a/src/Control/UAV/Ardupilot/Task.cpp
+++ b/src/Control/UAV/Ardupilot/Task.cpp
@@ -1678,6 +1678,8 @@ namespace Control
 
           m_lat = (double)gp.lat * 1e-07;
           m_lon = (double)gp.lon * 1e-07;
+          if (m_vehicle_type == VEHICLE_COPTER)
+            m_hae_msl = gp.alt * 1e-3;
 
           double d = WGS84::distance(m_ref_lat, m_ref_lon, m_ref_hae,
                                      lat, lon, getHeight());
@@ -2190,7 +2192,8 @@ namespace Control
           ias.value = (fp64_t)vfr_hud.airspeed;
           gs.value = (fp64_t)vfr_hud.groundspeed;
           m_gnd_speed = (int)vfr_hud.groundspeed;
-          m_hae_msl = vfr_hud.alt;
+          if (m_vehicle_type != VEHICLE_COPTER)
+            m_hae_msl = vfr_hud.alt;
 
           dispatch(ias);
           dispatch(gs);

--- a/src/Control/UAV/Ardupilot/Task.cpp
+++ b/src/Control/UAV/Ardupilot/Task.cpp
@@ -1729,6 +1729,9 @@ namespace Control
           m_estate.depth = -1;
           m_estate.alt = -1;
 
+          if (m_vehicle_type == VEHICLE_COPTER)
+            m_estate.alt = gp.relative_alt * 1e-3;
+
 
         }
 

--- a/src/Control/UAV/Ardupilot/Task.cpp
+++ b/src/Control/UAV/Ardupilot/Task.cpp
@@ -1673,13 +1673,17 @@ namespace Control
           mavlink_global_position_int_t gp;
           mavlink_msg_global_position_int_decode(msg, &gp);
 
+          // We need to wait untill we know the vehicle type to handle this
+          if (m_vehicle_type == VEHICLE_UNKNOWN)
+            return;
+
           double lat = Angles::radians((double)gp.lat * 1e-07);
           double lon = Angles::radians((double)gp.lon * 1e-07);
 
           m_lat = (double)gp.lat * 1e-07;
           m_lon = (double)gp.lon * 1e-07;
           if (m_vehicle_type == VEHICLE_COPTER)
-            m_hae_msl = gp.alt * 1e-3;
+            m_hae_msl = (double) gp.alt * 1.0e-3;
 
           double d = WGS84::distance(m_ref_lat, m_ref_lon, m_ref_hae,
                                      lat, lon, getHeight());

--- a/src/Monitors/Medium/Task.cpp
+++ b/src/Monitors/Medium/Task.cpp
@@ -219,8 +219,8 @@ namespace Monitors
           return;
 
         m_depth = msg->depth;
-        // For UAVs: Height is positive upwards, z is positive downwards.
-        m_altitude = msg->height - msg->z;
+        // For UAV Copters: Use the altitude field. Will be -1 for fixed-wings.
+        m_altitude = msg->alt;
       }
 
       void


### PR DESCRIPTION
This PR uses the right fields from mavlink to set Height, and also sets the altitude field in EstimatedState. 

The altitude is now used for medium-detection. The previous way it was done was not really valid. (NB: In Monitors/Medium; the altitude value is only used for copter. FW checks airspeed).