### PR TITLE
Control/Ardupilot: Various Ardupilot fixes

### DIFF
--- a/src/Control/UAV/Ardupilot/Task.cpp
+++ b/src/Control/UAV/Ardupilot/Task.cpp
@@ -2088,8 +2088,12 @@ namespace Control
 
           dispatch(d_roll);
           dispatch(d_pitch);
-          dispatch(d_head);
-          dispatch(d_z);
+
+          if (m_args.ardu_tracker)
+          {
+            dispatch(d_head);
+            dispatch(d_z);
+          }
 
           if (!m_args.ardu_tracker)
             return;

--- a/src/Control/UAV/Ardupilot/Task.cpp
+++ b/src/Control/UAV/Ardupilot/Task.cpp
@@ -1624,6 +1624,7 @@ namespace Control
             {
               setEntityState(IMC::EntityState::ESTA_ERROR, Status::CODE_MISSING_DATA);
               m_error_missing = true;
+              m_has_setup_rate = false;
               m_esta_ext = false;
             }
           }

--- a/src/Control/UAV/Ardupilot/Task.cpp
+++ b/src/Control/UAV/Ardupilot/Task.cpp
@@ -613,7 +613,7 @@ namespace Control
           {
             m_cloops &= ~cloops->mask;
 
-            if ((cloops->mask & IMC::CL_ROLL) && !m_ground)
+            if ((cloops->mask & IMC::CL_ROLL) && !m_ground && m_vehicle_type == VEHICLE_FIXEDWING)
             {
               mavlink_message_t msg;
               uint8_t buf[512];

--- a/src/Control/UAV/Ardupilot/Task.cpp
+++ b/src/Control/UAV/Ardupilot/Task.cpp
@@ -1945,6 +1945,11 @@ namespace Control
                 mode.mode = "MANUAL";
                 m_external = true;
                 break;
+              case CP_MODE_STABILIZE:
+                mode.autonomy = IMC::AutopilotMode::AL_MANUAL;
+                mode.mode = "STABILIZE";
+                m_external = true;
+                break;
               case CP_MODE_AUTO:
                 mode.autonomy = IMC::AutopilotMode::AL_AUTO;
                 mode.mode = "AUTO";
@@ -1956,6 +1961,12 @@ namespace Control
                 mode.mode = "LOITER";
                 trace("LOITER");
                 m_external = false;
+                break;
+              case CP_MODE_LAND:
+                mode.autonomy = IMC::AutopilotMode::AL_MANUAL;
+                mode.mode = "LAND";
+                trace("LAND");
+                m_external = true;
                 break;
               case CP_MODE_DUNE:
                 mode.autonomy = IMC::AutopilotMode::AL_AUTO;

--- a/src/Control/UAV/Ardupilot/Task.cpp
+++ b/src/Control/UAV/Ardupilot/Task.cpp
@@ -647,16 +647,23 @@ namespace Control
         void
         activateFBW(void)
         {
-          uint8_t buf[512];
-          mavlink_message_t msg;
+          if (m_vehicle_type == VEHICLE_FIXEDWING)
+          {
+            uint8_t buf[512];
+            mavlink_message_t msg;
 
-          mavlink_msg_set_mode_pack(255, 0, &msg,
-                                    m_sysid,
-                                    1,
-                                    6); //! FBWB is mode 6
+            mavlink_msg_set_mode_pack(255, 0, &msg,
+                                      m_sysid,
+                                      1,
+                                      6); //! FBWB is mode 6
 
-          uint16_t n = mavlink_msg_to_send_buffer(buf, &msg);
-          sendData(buf, n);
+            uint16_t n = mavlink_msg_to_send_buffer(buf, &msg);
+            sendData(buf, n);
+          }
+          else
+          {
+            debug("Tried to set FBW on a non-supported vehicle!");
+          }
         }
 
         void


### PR DESCRIPTION
Concerning "Control/UAV/Ardupilot: Force setup of rates if lost connection due to timeout.", is very useful when the pixhawk is restarted but not Dune (might happen during battery change)