### PR TITLE
[Waiting for other PRs] Control/Ardupilot: Add support for FBWA

### DIFF
--- a/src/Control/UAV/Ardupilot/Task.cpp
+++ b/src/Control/UAV/Ardupilot/Task.cpp
@@ -610,7 +610,7 @@ namespace Control
           {
             m_cloops &= ~cloops->mask;
 
-            if ((cloops->mask & IMC::CL_ROLL) && !m_ground)
+            if ((cloops->mask & IMC::CL_ROLL) && !m_ground && m_vehicle_type == VEHICLE_FIXEDWING)
             {
               mavlink_message_t msg;
               uint8_t buf[512];

--- a/src/Control/UAV/Ardupilot/Task.cpp
+++ b/src/Control/UAV/Ardupilot/Task.cpp
@@ -644,16 +644,23 @@ namespace Control
         void
         activateFBW(void)
         {
-          uint8_t buf[512];
-          mavlink_message_t msg;
+          if (m_vehicle_type == VEHICLE_FIXEDWING)
+          {
+            uint8_t buf[512];
+            mavlink_message_t msg;
 
-          mavlink_msg_set_mode_pack(255, 0, &msg,
-                                    m_sysid,
-                                    1,
-                                    6); //! FBWB is mode 6
+            mavlink_msg_set_mode_pack(255, 0, &msg,
+                                      m_sysid,
+                                      1,
+                                      6); //! FBWB is mode 6
 
-          uint16_t n = mavlink_msg_to_send_buffer(buf, &msg);
-          sendData(buf, n);
+            uint16_t n = mavlink_msg_to_send_buffer(buf, &msg);
+            sendData(buf, n);
+          }
+          else
+          {
+            debug("Tried to set FBW on a non-supported vehicle!");
+          }
         }
 
         void

--- a/src/Control/UAV/Ardupilot/Task.cpp
+++ b/src/Control/UAV/Ardupilot/Task.cpp
@@ -590,17 +590,20 @@ namespace Control
 
           if (cloops->enable)
           {
-            m_cloops |= cloops->mask;
-            if ((!m_args.ardu_tracker) && (cloops->mask & IMC::CL_PATH))
-            {
-              inf("Ardupilot tracker is NOT enabled");
-              m_cloops &= ~IMC::CL_PATH;
-            }
+//            if ((!m_args.ardu_tracker) && (cloops->mask & IMC::CL_PATH))
+//            {
+//              inf("Ardupilot tracker is NOT enabled");
+//              m_cloops &= ~IMC::CL_PATH;
+//            }
 
-            if (!(m_args.ardu_tracker) && (cloops->mask & IMC::CL_ROLL))
+            if (!m_args.ardu_tracker)
             {
-              onUpdateParameters();
-              activateFBW();
+              m_cloops |= cloops->mask;
+              if (cloops->mask & IMC::CL_ROLL)
+              {
+                onUpdateParameters();
+                activateFBW();
+              }
             }
           }
           else
@@ -860,7 +863,8 @@ namespace Control
             return;
           }
 
-          if (!((m_cloops & IMC::CL_PATH) && m_args.ardu_tracker))
+//        if (!((m_cloops & IMC::CL_PATH) && m_args.ardu_tracker))
+ 	  if (!m_args.ardu_tracker)
           {
             inf(DTR("path control is NOT active"));
             return;


### PR DESCRIPTION
This PR adds support for FBWA. It requires the IMC-messages in https://github.com/LSTS/imc/pull/12

Note: There are three additional commits here; 
- _Control/UAV/Ardupilot: Control loops handling allowed an unpredicted RC overwrite behavior_ is a part of a bugfix which will be handled in https://github.com/LSTS/dune/pull/60
- _Control/UAV/Ardupilot: In activateFBW(), check for correct vehicle type_ part is in PR https://github.com/LSTS/dune/pull/57.
- _Control/UAV/Ardupilot: Only send RC overide to zero when controlling a fixed wing_ is part of PR https://github.com/LSTS/dune/pull/57.

To not have to resolve the conflicts twice, this PR will be rebased when the above changes are merged in :)
