### PR TITLE
Feature/comms relay uav

### DIFF
--- a/etc/auv/maneuvers.ini
+++ b/etc/auv/maneuvers.ini
@@ -85,8 +85,10 @@ Min Actuation                           = 15
 Max Step Actuation                      = 10
 
 [Maneuver.CommsRelay]
-Enabled                                 = Simulation
+Enabled                                 = Always
 Entity Label                            = Communications Relay Maneuver
+Loitering Radius                        = 0
+Depth                                   = 0
 
 [Maneuver.CompassCalibration]
 Enabled                                 = Always

--- a/etc/uav/maneuvers.ini
+++ b/etc/uav/maneuvers.ini
@@ -34,6 +34,7 @@ Entity Label                               = Cover Area
 Laps                                       = 1
 Row Width                                  = 200
 
+
 [Maneuver.FollowReference.UAV]
 Enabled                                    = Always
 Entity Label                               = Follow Reference
@@ -41,3 +42,9 @@ Loitering Radius                           = 100
 Default Speed                              = 18
 Default Speed Units                        = m/s
 Default Z                                  = 150
+
+[Maneuver.CommsRelay]
+Enabled                                 = Always
+Entity Label                            = Communications Relay Maneuver
+Loitering Radius                        = 100
+Altitude                                = 150


### PR DESCRIPTION
This branch adds support for loitering in the CommsRelay maneuver. 
As a result it can now be executed by AUVs underwater and by fixed wing UAVs that need to be always moving.