### PR TITLE
Fix compilation error in Windows Visual Studio.

### DIFF
--- a/src/Transports/Seatrac/Task.cpp
+++ b/src/Transports/Seatrac/Task.cpp
@@ -30,6 +30,7 @@
 #include <map>
 #include <string>
 #include <cstring>
+#include <iterator>
 
 // DUNE headers.
 #include <DUNE/DUNE.hpp>


### PR DESCRIPTION
Hello,
Just wanted to let you know that to compile Dune in Windows Visual Studio you have to add to the Transports.Seatrack Task "#include ".
Otherwise you get an error std::back_inserter

Just a heads up.

Regards,
André