### PR TITLE
DUNE/Tasks/Task: added getEntity() member function to retrieve task e…

### DIFF
--- a/src/DUNE/Entities/BasicEntity.hpp
+++ b/src/DUNE/Entities/BasicEntity.hpp
@@ -119,7 +119,7 @@ namespace DUNE
       //! @param[in] label string to be compared against.
       //! @return true if the label and the string match, false otherwise.
       bool
-      operator==(const std::string label)
+      operator==(const std::string label) const
       {
         return getLabel() == label;
       }
@@ -128,7 +128,7 @@ namespace DUNE
       //! @param[in] id integer to use for comparison.
       //! @return true if the entity id and the integer match, false otherwise.
       bool
-      operator==(unsigned int id)
+      operator==(unsigned int id) const
       {
         return getId() == id;
       }

--- a/src/DUNE/Tasks/Task.cpp
+++ b/src/DUNE/Tasks/Task.cpp
@@ -110,7 +110,7 @@ namespace DUNE
     }
 
     Entities::BasicEntity*
-    Task::getEntity(const std::string& label)
+    Task::getLocalEntity(const std::string& label)
     {
       std::vector<Entities::BasicEntity*>::iterator it = std::find(m_entities.begin(), m_entities.end(), label);
       if (it == m_entities.end())

--- a/src/DUNE/Tasks/Task.cpp
+++ b/src/DUNE/Tasks/Task.cpp
@@ -41,6 +41,8 @@
 #include <DUNE/Tasks/Exceptions.hpp>
 #include <DUNE/Tasks/Task.hpp>
 #include <DUNE/Utils/XML.hpp>
+#include <DUNE/Entities/BasicEntity.hpp>
+#include <DUNE/Entities/EntityUtils.hpp>
 
 #if defined(DUNE_OS_LINUX)
 #  include <sys/prctl.h>
@@ -105,6 +107,16 @@ namespace DUNE
 
       m_entities.push_back(e);
       return e->getId();
+    }
+
+    Entities::BasicEntity*
+    Task::getEntity(const std::string& label)
+    {
+      std::vector<Entities::BasicEntity*>::iterator it = std::find(m_entities.begin(), m_entities.end(), label);
+      if (it == m_entities.end())
+          return NULL;
+      else
+        return (*it);
     }
 
     void

--- a/src/DUNE/Tasks/Task.hpp
+++ b/src/DUNE/Tasks/Task.hpp
@@ -450,7 +450,7 @@ namespace DUNE
       //! @param[in] label entity name/label.
       //! @return pointer to entity object.
       Entities::BasicEntity*
-      getEntity(const std::string& label);
+      getLocalEntity(const std::string& label);
 
       //! Test if task is stopping.
       //! @return true if task is stopping, false otherwise.

--- a/src/DUNE/Tasks/Task.hpp
+++ b/src/DUNE/Tasks/Task.hpp
@@ -445,6 +445,13 @@ namespace DUNE
         return entity;
       }
 
+      //! Retrieve pointer to a previously stored entity object
+      //! object.
+      //! @param[in] label entity name/label.
+      //! @return pointer to entity object.
+      Entities::BasicEntity*
+      getEntity(const std::string& label);
+
       //! Test if task is stopping.
       //! @return true if task is stopping, false otherwise.
       bool


### PR DESCRIPTION
…ntities by label.

By using the Entities::BasicEntity objects, this allows us to use this idiom:

```
Entities::BasicEntity* ent;
ent = getEntity(label);
if (!ent)
  ent = reserveEntity<Entities::BasicEntity>(label);
```

in pretty much the same way as this one:

```
int eid;
try
{
  eid = resolveEntity(label);
}
catch (Entities::EntityDataBase::NonexistentLabel& e)
{
  (void)e;
  eid = reserveEntity(label);
}
```
