### PR TITLE
DUNE/Tasks/Task: catch RestartNeeded exceptions when loading the task…

### DIFF
--- a/src/DUNE/Tasks/Task.cpp
+++ b/src/DUNE/Tasks/Task.cpp
@@ -695,7 +695,14 @@ namespace DUNE
           err(DTR("invalid parameter '%s'"), pitr->first.c_str());
       }
 
-      updateParameters(false);
+      try
+      {
+        updateParameters(false);
+      }
+      catch (RestartNeeded& e)
+      {
+        err(DTR("unable to load parameters: %s"), e.getError());
+      }
     }
   }
 }


### PR DESCRIPTION
… configuration.

This provides a quick fix for bug #75 by presenting a human readable error description if a RestartNeeded is thrown from inside updateParameters().
