### PR TITLE
DUNE/Control/BasicUAVAutopilot: Fixed bug

### DIFF
--- a/src/DUNE/Control/BasicUAVAutopilot.hpp
+++ b/src/DUNE/Control/BasicUAVAutopilot.hpp
@@ -113,6 +113,9 @@ namespace DUNE
         setEntityState(IMC::EntityState::ESTA_NORMAL, Status::CODE_ACTIVE);
         reset();
         onAutopilotActivation();
+
+        // Clear timestep timer
+        m_last_estate.clear();
       }
 
     private:


### PR DESCRIPTION
Fixed bug where delta timer was not reset on activation, leading to a situation where the delta time was calculated from the previous time the controller was used.