### PR TITLE
DUNE/Parsers: fixed NMEAWriter corruption after multiple calls to sen…

### DIFF
--- a/src/DUNE/Parsers/NMEAWriter.cpp
+++ b/src/DUNE/Parsers/NMEAWriter.cpp
@@ -100,6 +100,7 @@ namespace DUNE
       << std::hex
       << (unsigned)csum << "\r\n";
 
+      m_stream.seekp(5, m_stream.end);
       return m_stream.str();
     }
   }


### PR DESCRIPTION
…tence().

Every time NMEAWriter::sentence() is called, a checksum is appended to the stream, as is the final '\r\n'. If you call it multiple times, these get appended multiple times..

This fix simply rewinds the stream write head by 5 characters, so whatever is added to the end after the call to "sentence()", it just overwrites the checksum. The performance penalty should be negligible (compared to other possible solutions), and as a bonus, you can also append to the sentence, even after "sentence()" is called.

Cheers