### PR TITLE
Return cloned IMC message object as derived type.

### DIFF
--- a/programs/generators/imc_code.py
+++ b/programs/generators/imc_code.py
@@ -108,7 +108,7 @@ class Message:
         public.append(f)
 
         # clone()
-        f = Function('clone', 'Message*', const = True, inline = True)
+        f = Function('clone', '%(abbrev)s*' % node.attrib, const = True, inline = True)
         f.body('return new %(abbrev)s(*this);' % node.attrib)
         public.append(f)
 


### PR DESCRIPTION
It is automatically upcasted if necessary. Removes the need for a static_cast<DerivedType*>(...).