### PR TITLE
Transports/UDP: enable optional custom service type

### DIFF
--- a/src/Transports/UDP/Task.cpp
+++ b/src/Transports/UDP/Task.cpp
@@ -82,6 +82,8 @@ namespace Transports
       bool dynamic_nodes;
       // Only transmit messages from local system
       bool only_local;
+      // Optional custom service type
+      std::string custom_service;
     };
 
     // Internal buffer size.
@@ -178,6 +180,10 @@ namespace Transports
         .defaultValue("false")
         .description("Only transmit messsages from local system.");
 
+        param("Custom Service Type", m_args.custom_service)
+        .defaultValue("")
+        .description("Optional custom service type (imc+udp+<Custom Service Type>), empty entry gives default service (imc+udp)");
+
         // Allocate space for internal buffer.
         m_bfr = new uint8_t[c_bfr_size];
 
@@ -261,7 +267,17 @@ namespace Transports
           for (unsigned i = 0; i < itfs.size(); ++i)
           {
             std::stringstream os;
-            os << "imc+udp://" << itfs[i].address().str() << ":" << m_args.port
+            std::string service = "imc+udp";
+
+            // if custom service type is enabled
+            if (m_args.custom_service != "")
+            {
+              std::stringstream cs;
+              cs << service << "+" << m_args.custom_service;
+              service = cs.str();
+            }
+
+            os << service << "://" << itfs[i].address().str() << ":" << m_args.port
                << "/";
 
             IMC::AnnounceService announce;


### PR DESCRIPTION
We are using this for an automated feature to enable inter-vehicle IMC communication. By setting a seperate Transports.UDP task up with a custom service, e.g. intervehicle_formation, other vehicles can search for this feature and send specific messages to this vehicle without hardcoding remote IP's in static destinations. 
