### PR TITLE
DUNE/Control/PathController: Check track length.

### DIFF
--- a/src/DUNE/Control/PathController.cpp
+++ b/src/DUNE/Control/PathController.cpp
@@ -187,6 +187,11 @@ namespace DUNE
       .units(Units::Meter)
       .description("Admissible altitude when doing depth control");
 
+      param("Maximum Track Length", m_max_track_length)
+      .defaultValue("25000")
+	  .units(Units::Meter)
+	  .description("Maximum adimissible track length");
+
       m_ctx.config.get("General", "Absolute Maximum Depth", "50.0", m_btd.args.depth_limit);
       m_btd.args.depth_limit -= c_depth_margin;
 
@@ -360,6 +365,13 @@ namespace DUNE
 
       Coordinates::getBearingAndRange(m_ts.start, m_ts.end,
                                       &m_ts.track_bearing, &m_ts.track_length);
+
+      if (m_max_track_length > 0 && m_ts.track_length > m_max_track_length)
+      {
+    	  signalError(DTR("track length is too long"));
+    	  return;
+      }
+
 
       // Re-initializing tracking state values
       m_ts.start_time = now;

--- a/src/DUNE/Control/PathController.hpp
+++ b/src/DUNE/Control/PathController.hpp
@@ -458,6 +458,8 @@ namespace DUNE
       BottomTracker* m_btrack;
       //! Control loops last reference
       uint32_t m_scope_ref;
+      //! Maximum admitted track length
+      double m_max_track_length;
     };
   }
 }


### PR DESCRIPTION
If the user / planner commands a point too far away (> 25Km by default), the path controller goes into error mode ("track length too long").