### PR TITLE
Resolve forced rebuild of dune-core on cmake generation

### DIFF
--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -71,11 +71,12 @@ if(DUNE_VERSION_TPL AND DUNE_VERSION_OUT)
 
   if(files_cmp)
     file(RENAME "${DUNE_VERSION_OUT}.tmp" "${DUNE_VERSION_OUT}")
+  else()
+    file(REMOVE "${DUNE_VERSION_OUT}.tmp")
   endif()
 else()
   set(DUNE_CORE_SOURCES ${DUNE_CORE_SOURCES}
     ${DUNE_GENERATED}/src/DUNE/Version.cpp)
-  file(WRITE "${DUNE_GENERATED}/src/DUNE/Version.cpp" "")
 
   add_custom_target(dune-version
     COMMAND ${CMAKE_COMMAND}


### PR DESCRIPTION
If cmake is run repeatedly (e.g in an automatic build process), the Version.cpp file causes a re-linking to occur for dune-core every time. Removing the line that writes an empty file to Version.cpp resolves this, and allows the [comparison](https://github.com/LSTS/dune/blob/a016911e92eb7c96b590a652d11b1e230f1066a8/cmake/Version.cmake#L66) to work as intended. This comparison currently compares an empty file to the previous file, and will always recreate Version.cpp.