### PR TITLE
Remove the need for a rebuild of dune-core on cmake generation

### DIFF
--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -75,7 +75,10 @@ if(DUNE_VERSION_TPL AND DUNE_VERSION_OUT)
 else()
   set(DUNE_CORE_SOURCES ${DUNE_CORE_SOURCES}
     ${DUNE_GENERATED}/src/DUNE/Version.cpp)
-  file(WRITE "${DUNE_GENERATED}/src/DUNE/Version.cpp" "")
+    
+  if(NOT EXISTS "${DUNE_GENERATED}/src/DUNE/Version.cpp")
+    file(WRITE "${DUNE_GENERATED}/src/DUNE/Version.cpp" "")
+  endif()
 
   add_custom_target(dune-version
     COMMAND ${CMAKE_COMMAND}


### PR DESCRIPTION
If cmake is run repeatedly (e.g in an automatic build process), the Version.cpp file causes a re-linking to occur for dune-core every time. Only writing an empty Version.cpp file if it does not already exist resolves this, and allows the [comparison](https://github.com/LSTS/dune/blob/a016911e92eb7c96b590a652d11b1e230f1066a8/cmake/Version.cmake#L66) to work as intended. This comparison currently compares an empty file to the previous file, and will always recreate Version.cpp, thus causing a rebuild of dune-core and re-linking of external projects.

My last pull request failed because the file must exist for the build to succeed.