### PR TITLE
Fix possible race condition

### DIFF
--- a/src/Maneuver/FollowReference/AUV/Task.cpp
+++ b/src/Maneuver/FollowReference/AUV/Task.cpp
@@ -313,7 +313,7 @@ namespace Maneuver
           double curlat = state->lat;
           double curlon = state->lon;
           bool near_ref =
-          (pcs == NULL) ? false :
+          (pcs == NULL) || pcs->path_ref != m_last_desired_path.path_ref ? false :
           (pcs->flags & IMC::PathControlState::FL_NEAR) != 0;
 
           WGS84::displace(state->x, state->y, &curlat, &curlon);


### PR DESCRIPTION
Since the path_ref field is not checked in this comparison, the state machine can wrongfully enter loiter/elevator/hover ([link](https://github.com/LSTS/dune/blob/d7a7c8e3867ed98dfa7334cc577268630852dfe3/src/Maneuver/FollowReference/AUV/Task.cpp#L351)) or set the XY_NEAR flag ([link](https://github.com/LSTS/dune/blob/d7a7c8e3867ed98dfa7334cc577268630852dfe3/src/Maneuver/FollowReference/AUV/Task.cpp#L399)).

The race condition occurs if the path control state of the previous waypoint is received after switching to a new waypoint. The check for still_same_reference mitigates the problem, but it can still occur if the references are sent often. I encountered this when the path controller was implemented externally (e.g over a network).