### PR TITLE
Transports/Replay: Avoid clearing entity maps when resetting

### DIFF
--- a/src/Transports/Replay/Task.cpp
+++ b/src/Transports/Replay/Task.cpp
@@ -322,8 +322,6 @@ namespace Transports
           m_is = 0;
         }
         m_eid2eid.clear();
-        m_name2eid.clear();
-        m_eid2name.clear();
         m_tstats.clear();
         m_tgstats = Stats();
       }


### PR DESCRIPTION
This is pretty small so I'm just creating a PR directly without an issue.

Fixes entity assignment issues when replaying more than one log using the Replay task:

Entity maps `m_name2eid`/`m_eid2name` are created during the startup of the Replay
task, in `onEntityReservation()`, but they get cleared each time a log being
replayed finishes. When replaying more than one log (or one log several times)
that gives undefined entity IDs after the first replay. Leaving the entity maps
intact even when `reset()` is called solves this.