### PR TITLE
Plan/DB: Add reply to detailed PlanDB request.

### DIFF
--- a/src/Plan/DB/Task.cpp
+++ b/src/Plan/DB/Task.cpp
@@ -291,6 +291,7 @@ namespace Plan
               clearDatabase(*req);
               break;
             case IMC::PlanDB::DBOP_GET_STATE:
+            case IMC::PlanDB::DBOP_GET_DSTATE:
               m_reply.plan_id.clear();
               getDatabaseState(*req);
               break;


### PR DESCRIPTION
There's currently no reply for DSTATE requests. The simple plandb requests returns the full plan information in the plans_info field instead of being empty, contrary to the description in IMC (DBOP enumeration). The original intent for the simple state request cannot be implemented at this point without breaking external code.

This pull request adds identical behaviour for both STATE and DSTATE. An alternative to this pull request is to remove the DSTATE enumeration from IMC, as it is likely to be unused so far given the lack of a DUNE implementation. Personally, I think the latter is the better solution, unless the IMC STATE/DSTATE behavior is going to be implemented at some point.