### PR TITLE
Use const data array in Matrix constructor

### DIFF
--- a/src/DUNE/Math/Matrix.cpp
+++ b/src/DUNE/Math/Matrix.cpp
@@ -117,7 +117,7 @@ namespace DUNE
       }
     }
 
-    Matrix::Matrix(double* data, size_t r, size_t c)
+    Matrix::Matrix(const double* data, size_t r, size_t c)
     {
       if (!r || !c)
         throw Error("Invalid dimension!");

--- a/src/DUNE/Math/Matrix.hpp
+++ b/src/DUNE/Math/Matrix.hpp
@@ -81,7 +81,7 @@ namespace DUNE
       //! @param[in] data pointer to data to be copied to new matrix
       //! @param[in] r number of rows of new matrix
       //! @param[in] c number of columns of new matrix
-      Matrix(double* data, size_t r, size_t c);
+      Matrix(const double* data, size_t r, size_t c);
 
       //! Constructor.
       //! Construct a matrix of size rows*columns.


### PR DESCRIPTION
This a) is more const-correct and b) it allows initialization based
on both const and non-const arrays. If you have something like

```c++
const double data[3] = {1.0, 2.0, 3.0};
```

you can now do

```c++
DUNE::Math::Matrix m(data, 3, 1);
```

which was previously impossible when `data` was a const array.