### PR TITLE
DUNE/Math/Matrix: Make operator- a const method

### DIFF
--- a/src/DUNE/Math/Matrix.cpp
+++ b/src/DUNE/Math/Matrix.cpp
@@ -846,7 +846,7 @@ namespace DUNE
     }
 
     Matrix
-    Matrix::operator-(void)
+    Matrix::operator-(void) const
     {
       if (isEmpty())
         throw Error("Trying to access an empty matrix!");

--- a/src/DUNE/Math/Matrix.hpp
+++ b/src/DUNE/Math/Matrix.hpp
@@ -426,7 +426,7 @@ namespace DUNE
       //! This method implements the unary minus operator.
       //! @return resultant matrix
       Matrix
-      operator-(void);
+      operator-(void) const;
 
       //! This method multiplies a Matrix by a real number.
       //! @param[in] x real number


### PR DESCRIPTION
I think the unary minus operator should be made const. Otherwise, stuff like this will not compile:
```c++
const Matrix a(3);
Matrix b = -a;  // operator- is not a const method, and cannot be called on a const object
```
