### PR TITLE
Simulators/UAV: Consume WindSpeed messages to set simulator wind

### DIFF
--- a/etc/x8-06.ini
+++ b/etc/x8-06.ini
@@ -72,8 +72,8 @@ Maximum Bank                               = 30
 Debug Level                                = Debug
 
 [Simulators.UAV/Simulation]
-Stream Speed to North                      = -3
-Stream Speed to East                       = -1
+Stream Speed to North                      = 0
+Stream Speed to East                       = 0
 Simulation type                            = 5DOF
 Speed Time Constant                        = 2.0
 Bank Time Constant                         = 0.1

--- a/src/Simulators/UAV/Task.cpp
+++ b/src/Simulators/UAV/Task.cpp
@@ -288,6 +288,7 @@ namespace Simulators
         bind<IMC::DesiredSpeed>(this);
         bind<IMC::DesiredZ>(this);
         bind<IMC::DesiredPitch>(this);
+        bind<IMC::WindSpeed>(this);
       }
 
       void
@@ -578,6 +579,15 @@ namespace Simulators
 
         // ========= Debug ===========
         commandPrintOut(msg, &(msg->value));
+      }
+
+      void
+      consume(const IMC::WindSpeed* msg)
+      {
+        m_model->m_wind(0) = msg->speed * std::sin(msg->direction);
+        m_model->m_wind(1) = msg->speed * std::cos(msg->direction);
+
+        inf("wind set to (%1.2f, %1.2f)", m_model->m_wind(0), m_model->m_wind(1));
       }
 
       /*


### PR DESCRIPTION
For the simulation profile, set the default wind to 0 and allow to set it with WindSpeed messages