### PR TITLE
DUNE/Hardware/GPIO: Make GPIO class non-copyable

### DIFF
--- a/src/DUNE/Hardware/GPIO.hpp
+++ b/src/DUNE/Hardware/GPIO.hpp
@@ -82,6 +82,12 @@ namespace DUNE
       getValue(void);
 
     private:
+      //! Disallow copy constructor.
+      GPIO(const GPIO&);
+
+      //! Disallow copy assignment.
+      GPIO& operator=(const GPIO&);
+
       //! GPIO number.
       unsigned int m_number;
       //! GPIO direction.


### PR DESCRIPTION
GPIO objects should not be possible to copy. This PR fixes that.

Most people wouldn't do
```
GPIO g1(1);
GPIO g2(g1);
GPIO g3 = g1;
```
but some fools such as myself might try to
```
std::vector<GPIO> v;
v.emplace_back(1);
v.emplace_back(2),
```
Both of these give only run time errors, but by disabling the copy constructor and copy assignment operators, we turn them into compile time errors. Much better!