### PR TITLE
DUNE/Math/Matrix: Make identity constructor explicit

### DIFF
--- a/src/DUNE/Math/Matrix.hpp
+++ b/src/DUNE/Math/Matrix.hpp
@@ -99,7 +99,7 @@ namespace DUNE
       //! Constructor.
       //! Construct a square identity matrix of size n
       //! param[in] n size of new matrix (n * n)
-      Matrix(size_t n);
+      explicit Matrix(size_t n);
 
       //! Constructor.
       //! Construct a diagonal matrix using the values in data


### PR DESCRIPTION
Another of my matrix library oneliner changes.

I think the `Matrix(size_t n)` constructor (which creates a n-by-n identity matrix) should be marked explicit. Otherwise, stuff like this is possible:
```c++
Matrix m;        // Empty matrix.
m.vertCat(2);    // Implicit matrix construction.
m.vertCat(2.2);  // Implicit conversion to size_t and implicit matrix construction.
```
after which the matrix `m` is
```
1 0 
0 1 
1 0 
0 1
```
By making the constructor explicit the above will not compile, which I think is preferable.