### PR TITLE
More accurate displace for WGS84

### DIFF
--- a/src/DUNE/Coordinates/WGS84.hpp
+++ b/src/DUNE/Coordinates/WGS84.hpp
@@ -182,7 +182,9 @@ namespace DUNE
         toECEF(*lat, *lon, *hae, &x, &y, &z);
 
         // Compute Geocentric latitude
-        double phi = std::atan2(z, std::sqrt(x * x + y * y));
+        double N = computeRn(*lat);
+        double p = std::sqrt(x * x + y * y);
+        double phi = std::atan2(z,p*(1 - c_wgs84_e2 * N / (N + *hae)));
 
         // Compute all needed sine and cosine terms for conversion.
         double slon = std::sin(*lon);

--- a/src/DUNE/Coordinates/WGS84.hpp
+++ b/src/DUNE/Coordinates/WGS84.hpp
@@ -287,7 +287,6 @@ namespace DUNE
         getNEBearingAndRange(lat1, lon1, lat2, lon2, azimuth, &tmp);
       }
 
-    private:
       //! Convert WGS-84 coordinates to ECEF (Earch Center Earth Fixed) coordinates.
       //!
       //! @param[in] lat WGS-84 latitude (rad).
@@ -349,6 +348,7 @@ namespace DUNE
         }
       }
 
+    private:
       //! Compute the radius of curvature in the prime vertical (Rn).
       //!
       //! @param[in] lat WGS-84 latitude (rad).


### PR DESCRIPTION
As discussed with @mariacosta and @zepinto 

This should perhaps have been two PRs, but they are very small and in the same file :)

- ae60233 More accurate displace: This also considers the latitude when displacing.
- 0ead2aa makes to/fromECEF public, which I have found useful in some other applications, but is not necessary in this context

We have flown a lot with this new displace function. Let me know if I should find a reference for the formula, as I don't have it off the top of my head.