### PR TITLE
WIP: DUNE/Parsers/APConfig: added skeleton of parser for Ardupilot config

### DIFF
--- a/src/DUNE/Parsers/APConfig.cpp
+++ b/src/DUNE/Parsers/APConfig.cpp
@@ -1,0 +1,141 @@
+//***************************************************************************
+// Copyright 2007-2017 Universidade do Porto - Faculdade de Engenharia      *
+// Laboratório de Sistemas e Tecnologia Subaquática (LSTS)                  *
+//***************************************************************************
+// This file is part of DUNE: Unified Navigation Environment.               *
+//                                                                          *
+// Commercial Licence Usage                                                 *
+// Licencees holding valid commercial DUNE licences may use this file in    *
+// accordance with the commercial licence agreement provided with the       *
+// Software or, alternatively, in accordance with the terms contained in a  *
+// written agreement between you and Faculdade de Engenharia da             *
+// Universidade do Porto. For licensing terms, conditions, and further      *
+// information contact lsts@fe.up.pt.                                       *
+//                                                                          *
+// Modified European Union Public Licence - EUPL v.1.1 Usage                *
+// Alternatively, this file may be used under the terms of the Modified     *
+// EUPL, Version 1.1 only (the "Licence"), appearing in the file LICENCE.md *
+// included in the packaging of this file. You may not use this work        *
+// except in compliance with the Licence. Unless required by applicable     *
+// law or agreed to in writing, software distributed under the Licence is   *
+// distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF     *
+// ANY KIND, either express or implied. See the Licence for the specific    *
+// language governing permissions and limitations at                        *
+// https://github.com/LSTS/dune/blob/master/LICENCE.md and                  *
+// http://ec.europa.eu/idabc/eupl.html.                                     *
+//***************************************************************************
+// Author: Kristoffer Gryte                                                 *
+//***************************************************************************
+
+// ISO C++ 98 headers.
+#include <map>
+#include <string>
+#include <iomanip>
+#include <cstdio>
+#include <cctype>
+#include <cstring>
+#include <cstdlib>
+#include <fstream>
+#include <algorithm>
+
+// DUNE headers.
+#include <DUNE/Version.hpp>
+#include <DUNE/System/Error.hpp>
+#include <DUNE/FileSystem/Path.hpp>
+#include <DUNE/Utils/String.hpp>
+#include <DUNE/Parsers/Exceptions.hpp>
+#include <DUNE/Parsers/APConfig.hpp>
+
+namespace DUNE
+{
+  //! Parses Ardupilot configuration files
+  namespace Parsers
+  {
+    using FileSystem::Path;
+    using Utils::String;
+
+    //! Maximum buffer size.
+    static const size_t c_max_bfr_size = 1024;
+
+    //! Retrieve option and respective value from a line.
+    //! @param[in] line line.
+    //! @param[out] option option string.
+    //! @param[out] value option value.
+    //! @return true if line is an option assignment, false otherwise.
+    static bool
+    getOptionAndValue(const char* line, char* option, float* value)
+    {
+      //TODO: separation symbols can also be comma
+      int rv = std::sscanf(line, " %50s %f ", option, value);
+      if (rv != 2)
+      {
+        return false;
+      }
+
+      return true;
+    }
+
+    void
+    APConfig::parseFile(const char* fname)
+    {
+      char line[c_max_bfr_size] = {0};
+      char option[c_max_bfr_size] = {0};
+      float arg = 0.0;
+      char tmp[c_max_bfr_size] = {0};
+      size_t line_count = 0;
+      std::FILE* fd = std::fopen(fname, "r");
+
+      if (fd == 0)
+      {
+        throw FileOpenError(fname, System::Error::getLastMessage());
+      }
+
+      while (std::fscanf(fd, " %1023[^\n] ", line) == 1)
+      {
+        ++line_count;
+
+        // Ignore comments.
+        if (line[0] == '#')
+          continue;
+
+        // Option and value.
+        if(getOptionAndValue(line, option, &arg))
+        {
+          //inf("Parsed %s = %f",option, arg);
+          String::rtrim(option);
+          std::strncpy(tmp, option, c_max_bfr_size);
+          m_params[option] = arg;
+        }
+        // Syntax error.
+        else
+        {
+          //throw SyntaxError(fname, line_count);
+          DUNE_WRN("APConfig","SyntaxError in " << fname << "line: " << line_count);
+          continue;
+        }
+      }
+      std::fclose(fd);
+    }
+
+    int
+    APConfig::update(const char* fname)
+    {
+      try
+      {
+        parseFile(fname);
+      }
+      catch (FileOpenError& e)
+      {
+        DUNE_WRN("APConfig", e.what());
+        return 0;
+      }
+      return 1;
+    }
+
+
+    APConfig::APConfig(const char* fname)
+    {
+      APConfig::update(fname);
+    }
+  }
+}

--- a/src/DUNE/Parsers/APConfig.hpp
+++ b/src/DUNE/Parsers/APConfig.hpp
@@ -1,0 +1,96 @@
+//***************************************************************************
+// Copyright 2007-2017 Universidade do Porto - Faculdade de Engenharia      *
+// Laboratório de Sistemas e Tecnologia Subaquática (LSTS)                  *
+//***************************************************************************
+// This file is part of DUNE: Unified Navigation Environment.               *
+//                                                                          *
+// Commercial Licence Usage                                                 *
+// Licencees holding valid commercial DUNE licences may use this file in    *
+// accordance with the commercial licence agreement provided with the       *
+// Software or, alternatively, in accordance with the terms contained in a  *
+// written agreement between you and Faculdade de Engenharia da             *
+// Universidade do Porto. For licensing terms, conditions, and further      *
+// information contact lsts@fe.up.pt.                                       *
+//                                                                          *
+// Modified European Union Public Licence - EUPL v.1.1 Usage                *
+// Alternatively, this file may be used under the terms of the Modified     *
+// EUPL, Version 1.1 only (the "Licence"), appearing in the file LICENCE.md *
+// included in the packaging of this file. You may not use this work        *
+// except in compliance with the Licence. Unless required by applicable     *
+// law or agreed to in writing, software distributed under the Licence is   *
+// distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF     *
+// ANY KIND, either express or implied. See the Licence for the specific    *
+// language governing permissions and limitations at                        *
+// https://github.com/LSTS/dune/blob/master/LICENCE.md and                  *
+// http://ec.europa.eu/idabc/eupl.html.                                     *
+//***************************************************************************
+// Author: Kristoffer Gryte                                                 *
+//***************************************************************************
+
+#ifndef DUNE_PARSERS_APCONFIG_HPP_INCLUDED_
+#define DUNE_PARSERS_APCONFIG_HPP_INCLUDED_
+
+// ISO C++ 98 headers.
+#include <map>
+#include <string>
+#include <sstream>
+#include <vector>
+#include <stdexcept>
+#include <cstring>
+
+// DUNE headers.
+#include <DUNE/Config.hpp>
+#include <DUNE/Utils/String.hpp>
+#include <DUNE/Streams/Terminal.hpp>
+#include <DUNE/Casts.hpp>
+
+#include <map>
+
+namespace DUNE
+{
+  namespace Parsers
+  {
+    // Export DLL Symbol.
+    class DUNE_DLL_SYM APConfig;
+
+    //! Parser for Ardupilot config files, with space as separator
+    //! Note that leading
+    //! and trailing whitespaces are removed from values. Character
+    //! case in "option" identifiers is discarded. Lines beginning
+    //! with "#" or ";" are ignored and may be used to provide
+    //! comments.
+    class APConfig
+    {
+    public:
+      //! Default constructor.
+      APConfig(void)
+      { }
+
+      //! Create the parser and parse a configuration file.
+      //! @param fname name of the configuration file to parse.
+      APConfig(const char* fname);
+
+      //! Parse a configuration file.
+      //! @param fname name of the configuration file to parse.
+      void
+      parseFile(const char* fname);
+
+      //! Update a configuration file.
+      //! @param fname name of the configuration file to parse.
+      //! @return 1 on success
+      int
+      update(const char* fname);
+
+      //! Return a copy of the parameters
+      const std::map<std::string, float>& getParams(void) const {return m_params;}
+    private:
+      //! Representation of the configuration file as a map.
+      std::map<std::string, float> m_params;
+      //! List of parsed files.
+      std::vector<std::string> m_files;
+
+    };
+  }
+}
+
+#endif


### PR DESCRIPTION
As mentioned in our previous dev call, we have made a parser for Ardupilot configuration files. It is essentially a simplified version of the existing DUNE/Parsers/Config parser.

It has been tested, but not extensively.

Known limitations:

- AP config files allow both space and comma as separator between the parameter name and value. This only supports space for now
- Have not added support for setting/getting a single parameter, as our use-case was to read a set of parameters from a file and treat these as a whole. We used the update function to update the whole parameter list if the parameter file path was changed.

I don't think this should be merged in its current state, but I put it here if someone is interested in continuing this work (as I don't see myself continuing down this path in the immediate future). 

Open for comments/questions, for future reference :)