### PR TITLE
Control/UAV/Ardupilot: fixed scaling of raw IMU data

### DIFF
--- a/src/Control/UAV/Ardupilot/Task.cpp
+++ b/src/Control/UAV/Ardupilot/Task.cpp
@@ -1768,23 +1768,28 @@ namespace Control
           double tstamp = Clock::getSinceEpoch();
 
           IMC::Acceleration acce;
-          acce.x = raw.xacc;
-          acce.y = raw.yacc;
-          acce.z = raw.zacc;
+          // raw_imu acc unit is in milli gs
+          // g used in AP is 9.80665 (see libraries/AP_Math/definitions.h)
+          acce.x = raw.xacc*0.001*9.80665;
+          acce.y = raw.yacc*0.001*9.80665;
+          acce.z = raw.zacc*0.001*9.80665;
           acce.setTimeStamp(tstamp);
           dispatch(acce);
 
+          // raw_imu ars unit is milli rad/s
           IMC::AngularVelocity avel;
-          avel.x = raw.xgyro;
-          avel.y = raw.ygyro;
-          avel.z = raw.zgyro;
+          avel.x = raw.xgyro*0.001;
+          avel.y = raw.ygyro*0.001;
+          avel.z = raw.zgyro*0.001;
           avel.setTimeStamp(tstamp);
           dispatch(avel);
 
+          // raw_imu mag unit is milli Tesla
+          // IMC mag unit is Gauss = 10^-4 Tesla
           IMC::MagneticField magn;
-          magn.x = raw.xmag;
-          magn.y = raw.ymag;
-          magn.z = raw.zmag;
+          magn.x = raw.xmag*0.1;
+          magn.y = raw.ymag*0.1;
+          magn.z = raw.zmag*0.1;
           magn.setTimeStamp(tstamp);
           dispatch(magn);
         }


### PR DESCRIPTION
The data output from the Ardupilot task is not scaled correctly. This has been confirmed by both data from SITL and physical flights (see the below picture), and is fixed by this commit.

![image](https://user-images.githubusercontent.com/1384876/46860926-b6b6cf80-ce11-11e8-8503-04ef4ec0aa68.png)