### PR TITLE
DUNE/IMC/Bus: Fix concurrency bug (caused segfaults)

### DIFF
--- a/src/DUNE/IMC/Bus.cpp
+++ b/src/DUNE/IMC/Bus.cpp
@@ -143,6 +143,7 @@ namespace DUNE
     const std::vector<TransportBindings*>
     Bus::getBindings(void)
     {
+      Concurrency::ScopedRWLock l(m_lock);
       return m_bind_msgs;
     }
   }


### PR DESCRIPTION
This seems to fix #151

### Cause
Simultaneous access of shared memory from multiple threads. 

### Rationale
The bus is responsible for all the recipients of IMC messages. In this setting, we are focused on the mechanism to register a new task to the bus, through the method `registerRecipient`. 

https://github.com/LSTS/dune/blob/2a32fbe42d241bfa207681a75c46b69112c1bc65/src/DUNE/IMC/Bus.cpp#L81

This is called when a task issues a `bind<>` command. For most tasks, this is done at task object construction. 

The daemon thread constructs all tasks in its own thread, before any new threads are spawned. Thus, for the tasks issuing a bind in the constructor, we have no problems. 

After all tasks are constructed, the new task threads are spawned. Now enter the Logger task. At first start, it will try to start a new log file. At the beginning of the log file, it fetches the list of recipients from the bus:
https://github.com/LSTS/dune/blob/2a32fbe42d241bfa207681a75c46b69112c1bc65/src/Transports/Logging/Task.cpp#L274

which gets the bindings from the bus' recipients through the _vector_ `m_bind_msg`
https://github.com/LSTS/dune/blob/2a32fbe42d241bfa207681a75c46b69112c1bc65/src/DUNE/IMC/Bus.cpp#L146

However, there are some tasks that attempt to register new binds _after_ thread spawn. Notable examples are `Transports.UDP` and `Transports.HTTP` which issues binds in their respective `onParameterUpdate` to allow for dynamic message binds. 

This causes the bus' vector `m_bind_msg` to grow. An `std::vector` can reallocate itself during size increase. If the call to `Bus::getBindings` is interrupted, and new values are inserted through run-time binds, the returned memory can be invalid, causing a seg-fault. 

### The fix
Lock the fetching of the vector with the same mutex used to protect the vector during insertion of new elements. 

### Other notes
The compromised function is only called from the Logger task. 


### Tests
We let the test described in #151 run for 12 straight hours, with no startup issues. 
