### PR TITLE
Algorithms/Base64: Replace regex.h usage with standard library

### DIFF
--- a/programs/tests/test_Base64.cpp
+++ b/programs/tests/test_Base64.cpp
@@ -51,31 +51,42 @@ main(void)
   std::string str = "f";
   test.boolean("encode(f) == 'Zg=='", Base64::encode(str) == "Zg==");
   test.boolean("decode(Zg==) == 'f'", Base64::decode(Base64::encode(str)) == "f");
+  test.boolean("validBase64(encode(f))", Base64::validBase64(Base64::encode(str)));
+  test.boolean("!validBase64(f)", !Base64::validBase64(str));
 
   // String: fo - Zm8=
   str = "fo";
   test.boolean("encode(fo) == 'Zm8='", Base64::encode(str) == "Zm8=");
   test.boolean("decode(Zm8=) == 'fo'", Base64::decode(Base64::encode(str)) == "fo");
+  test.boolean("validBase64(encode(fo))", Base64::validBase64(Base64::encode(str)));
+  test.boolean("!validBase64(fo)", !Base64::validBase64(str));
 
   // String: foo - Zm9v
   str = "foo";
   test.boolean("encode(foo) == 'Zm9v'", Base64::encode(str) == "Zm9v");
   test.boolean("decode(Zm9v) == 'foo'", Base64::decode(Base64::encode(str)) == "foo");
+  test.boolean("validBase64(encode(foo))", Base64::validBase64(Base64::encode(str)));
+  test.boolean("!validBase64(foo)", !Base64::validBase64(str));
 
   // String: foob - Zm9vYg==
   str = "foob";
   test.boolean("encode(foob) == 'Zm9vYg=='", Base64::encode(str) == "Zm9vYg==");
   test.boolean("decode(Zm9vYg==) == 'foob'", Base64::decode(Base64::encode(str)) == "foob");
+  test.boolean("validBase64(encode(foob))", Base64::validBase64(Base64::encode(str)));
 
   // String: fooba - Zm9vYmE=
   str = "fooba";
   test.boolean("encode(fooba) == 'Zm9vYmE='", Base64::encode(str) == "Zm9vYmE=");
   test.boolean("decode(Zm9vYmE=) == 'fooba'", Base64::decode(Base64::encode(str)) == "fooba");
+  test.boolean("validBase64(encode(fooba))", Base64::validBase64(Base64::encode(str)));
+  test.boolean("!validBase64(fooba)", !Base64::validBase64(str));
 
   // String: foobar - Zm9vYmFy
   str = "foobar";
   test.boolean("encode(foobar) == 'Zm9vYmFy'", Base64::encode(str) == "Zm9vYmFy");
   test.boolean("decode(Zm9vYmFy) == 'foobar'", Base64::decode(Base64::encode(str)) == "foobar");
+  test.boolean("validBase64(encode(foobar))", Base64::validBase64(Base64::encode(str)));
+  test.boolean("!validBase64(foobar)", !Base64::validBase64(str));
 
   /* RFC 2045 Strings Test */
 
@@ -83,11 +94,15 @@ main(void)
   str = "*";
   test.boolean("encode(*) == 'Kg=='", Base64::encode(str) == "Kg==");
   test.boolean("decode(Kg==) == '*'", Base64::decode(Base64::encode(str)) == "*");
+  test.boolean("validBase64(encode(*))", Base64::validBase64(Base64::encode(str)));
+  test.boolean("!validBase64(*)", !Base64::validBase64(str));
 
   // String: "Hello World!" - "SGVsbG8gV29ybGQh"
   str = "Hello World!";
   test.boolean("encode(Hello World!) == 'SGVsbG8gV29ybGQh'", Base64::encode(str) == "SGVsbG8gV29ybGQh");
-  test.boolean("decode(SGVsbG8gV29ybGQh) == 'Hello World!'", Base64::decode(Base64::encode(str)) == "Hello World!")
-;
+  test.boolean("decode(SGVsbG8gV29ybGQh) == 'Hello World!'", Base64::decode(Base64::encode(str)) == "Hello World!");
+  test.boolean("validBase64(encode(Hello World!))", Base64::validBase64(Base64::encode(str)));
+  test.boolean("!validBase64(Hello World!)", !Base64::validBase64(str));
+
   return 0;
 }

--- a/src/DUNE/Algorithms/Base64.cpp
+++ b/src/DUNE/Algorithms/Base64.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <cstring>
 #include <cstdlib>
-#include <regex.h>
+#include <regex>
 
 
 // DUNE headers.
@@ -46,7 +46,9 @@ namespace DUNE
                                         "abcdefghijklmnopqrstuvwxyz"
                                         "0123456789+/";
     //! Base64 regular expression
-    static const char* c_b64_regex = "^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$";
+    static const std::basic_regex<char> c_b64_regex("^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|"
+                                                    "[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$",
+                                                    std::regex_constants::extended);
 
     //! Base64 decoding table.
     static const unsigned char c_b64_de[] =
@@ -66,21 +68,9 @@ namespace DUNE
 
     //! Verify if string is a valid Base64
     bool
-	Base64::validBase64(const  char* str)
+    Base64::validBase64(const  char* str)
     {
-    	regex_t  base64R;
-    	if(regcomp(&base64R,c_b64_regex,REG_EXTENDED|REG_NOSUB) != 0 )
-    	{
-    		regfree(&base64R);
-    		return false;
-    	}
-    	if(regexec(&base64R,str,0,NULL,0) == REG_NOMATCH)
-    	{
-    		regfree(&base64R);
-    		return false;
-    	}
-    	regfree(&base64R);
-    	return true;
+      return std::regex_match(str, c_b64_regex);
     }
     //! Encode a sequence of bytes in Base64.
     std::string


### PR DESCRIPTION
Resolves the issue with windows compilation in #141. It is an alternative to the pull request in #150, but does not introduce an additional regex library. Does require C+11, so shouldn't be merged before #114 is resolved.

Added some tests as well