### PR TITLE
DUNE/Maneuvers/Maneuver: Correct wrong method docstring

### DIFF
--- a/src/DUNE/Maneuvers/Maneuver.hpp
+++ b/src/DUNE/Maneuvers/Maneuver.hpp
@@ -252,7 +252,7 @@ namespace DUNE
       void
       signalNoAltitude(void);
 
-      //! Signal an error.
+      //! Signal maneuver completion.
       //! This method should be used by subclasses to signal maneuver completion.
       //! @param msg completion message
       void


### PR DESCRIPTION
Noticed a small mistake in the Maneuver base class method docstrings. Probably someone copied from another method and forgot to modify.