### PR TITLE
Skip initial part of replay

### DIFF
--- a/etc/testing/replays/sgnav-replay.ini
+++ b/etc/testing/replays/sgnav-replay.ini
@@ -48,6 +48,7 @@ Distance Between GPS and CG             = 0.25
 Enabled         = Always
 Entity Label    = Replay
 Time Multiplier = 1.0
+Seconds to skip = 0.0
 # NOTE: Add entity names that replay should consider
 Entities        = Depth Sensor,
                   AHRS,

--- a/src/Transports/Replay/Task.cpp
+++ b/src/Transports/Replay/Task.cpp
@@ -213,6 +213,20 @@ namespace Transports
       }
 
       void
+      updateEntityMap(IMC::Message* m)
+      {
+        IMC::EntityInfo* ei = static_cast<IMC::EntityInfo*>(m);
+        Name2Eid::iterator itr = m_name2eid.find(ei->label);
+
+        if (itr != m_name2eid.end())
+        {
+          m_eid2eid[ei->id] = itr->second;
+
+          trace("entity %s %d --> %d", ei->label.c_str(), (int)ei->id, (int)itr->second);
+        }
+      }
+
+      void
       startReplay(const std::string& file)
       {
         if (isActive())
@@ -371,20 +385,6 @@ namespace Transports
         m_eid2eid.clear();
         m_tstats.clear();
         m_tgstats = Stats();
-      }
-
-      void
-      updateEntityMap(IMC::Message* m)
-      {
-        IMC::EntityInfo* ei = static_cast<IMC::EntityInfo*>(m);
-        Name2Eid::iterator itr = m_name2eid.find(ei->label);
-
-        if (itr != m_name2eid.end())
-        {
-          m_eid2eid[ei->id] = itr->second;
-
-          trace("entity %s %d --> %d", ei->label.c_str(), (int)ei->id, (int)itr->second);
-        }
       }
 
       void

--- a/src/Transports/Replay/Task.cpp
+++ b/src/Transports/Replay/Task.cpp
@@ -338,6 +338,20 @@ namespace Transports
       }
 
       void
+      updateEntityMap(IMC::Message* m)
+      {
+        IMC::EntityInfo* ei = static_cast<IMC::EntityInfo*>(m);
+        Name2Eid::iterator itr = m_name2eid.find(ei->label);
+
+        if (itr != m_name2eid.end())
+        {
+          m_eid2eid[ei->id] = itr->second;
+
+          trace("entity %s %d --> %d", ei->label.c_str(), (int)ei->id, (int)itr->second);
+        }
+      }
+
+      void
       dispatchWithNewTime(IMC::Message* m)
       {
         double original_ts;
@@ -419,15 +433,7 @@ namespace Transports
             else if (m->getId() == DUNE_IMC_ENTITYINFO)
             {
               // Update entity id map
-              IMC::EntityInfo* ei = static_cast<IMC::EntityInfo*>(m);
-              Name2Eid::iterator itr = m_name2eid.find(ei->label);
-
-              if (itr != m_name2eid.end())
-              {
-                m_eid2eid[ei->id] = itr->second;
-
-                trace("entity %s %d --> %d", ei->label.c_str(), (int)ei->id, (int)itr->second);
-              }
+              updateEntityMap(m);
             }
 
             m->setSourceEntity(mapEntity(m->getSourceEntity()));


### PR DESCRIPTION
Added functionality to skip the initial <skip> seconds of a log replay, inspired by dune-lsfreplay. This is done by simply looping through the messages in the log file, until the difference between timestamp of the message and the start of the log is larger than the desired number of seconds to skip. While looping through messages, EntityInfo messages are handled, to build a map of the Entities.

This has been tested, and works for the functionality that I needed, but perhaps there is something I've missed?