### PR TITLE
DUNE/IMC/MessageList: Add empty() method

### DIFF
--- a/src/DUNE/IMC/MessageList.hpp
+++ b/src/DUNE/IMC/MessageList.hpp
@@ -126,6 +126,14 @@ namespace DUNE
         return m_list.end();
       }
 
+      //! Check if the list is empty.
+      //! @return true if the list is empty.
+      bool
+      empty(void) const
+      {
+        return m_list.empty();
+      }
+
       //! Add a new element at the end of the list, after its current
       //! last element. The content of this new element is initialized
       //! to a copy of 'msg'.


### PR DESCRIPTION
This is just a tiny nice-to-have change. Most STL containers have both a `size()` and an `empty()` method, but `IMC::MessageList` only has `size()`. Many programmers are used to having an `empty()` method on container-like classes, so I've added `IMC::MessageList::empty()` for convenience.

Lets you do stuff like
```cpp
void consume(const IMC::Distance* msg)
{
  if (msg->location.empty())
  {
    war("IMC::Distance location undefined");
  }
}
```

instead of for instance

```cpp
void consume(const IMC::Distance* msg)
{
  if (msg->location.size() == 0)
  {
    war("IMC::Distance location undefined");
  }
}
```

which is somewhat uglier.