### PR TITLE
Make Task::bind protected (instead of private)

### DIFF
--- a/src/DUNE/Tasks/Task.hpp
+++ b/src/DUNE/Tasks/Task.hpp
@@ -608,6 +608,17 @@ namespace DUNE
                new Consumer<T, IMC::Message>(*task_obj, func));
       }
 
+      //! Register a consumer for a given message identifier.
+      //! @param[in] message_id message identifier.
+      //! @param[in] consumer consumer object.
+      void
+      bind(unsigned int message_id, AbstractConsumer* consumer)
+      {
+        spew("registering consumer for '%s'",
+             IMC::Factory::getAbbrevFromId(message_id).c_str());
+        m_recipient->bind(message_id, consumer);
+      }
+
       //! Request task to start/resume normal execution.
       void
       requestActivation(void);
@@ -808,17 +819,6 @@ namespace DUNE
 
       void
       run(void);
-
-      //! Register a consumer for a given message identifier.
-      //! @param[in] message_id message identifier.
-      //! @param[in] consumer consumer object.
-      void
-      bind(unsigned int message_id, AbstractConsumer* consumer)
-      {
-        spew("registering consumer for '%s'",
-             IMC::Factory::getAbbrevFromId(message_id).c_str());
-        m_recipient->bind(message_id, consumer);
-      }
 
       //! Consume QueryEntityState messages and reply accordingly.
       //! @param[in] msg QueryEntityState message.


### PR DESCRIPTION
Say you have two tasks that both dispatch the same IMC message type, and some other tasks that consume those messages. The consuming tasks must then choose which source entities they want messages from. I've been thinking about making a new base task class, that inherits `DUNE::Tasks::Task`, and implements a new method maybe called `filteredBind` that automatically sets up a filter on incoming message source entity. This requires me to use a custom consumer class, which means I need access to `bind(unsigned int message_id, AbstractConsumer* consumer)` so I can call it with my custom consumer.

An alternative would be to add this `filteredBind` directly to `DUNE::Tasks::Task`, but I think making `bind(unsigned int message_id, AbstractConsumer* consumer)` protected is a better solution, because it allows creating any new base task class without further modifying `DUNE::Tasks::Task` each time.

What do you think?