### PR TITLE
Update IMC Generator utils to create MD5 on RHEL.

### DIFF
--- a/programs/generators/imc/utils.py
+++ b/programs/generators/imc/utils.py
@@ -154,7 +154,7 @@ def abbrev_to_macro(abbrev, prefix = ''):
 
 # Compute MD5 sum.
 def compute_md5(imc_xml):
-    m = hashlib.md5()
+    m = hashlib.new('md5',usedforsecurity=False)
     m.update(open(imc_xml, 'rb').read())
     return m.hexdigest()
 


### PR DESCRIPTION
Update IMC Generator utils to create MD5 on RHEL

RHEL prevents the use of MD5 sum for security purposes.
The programs/generators/imc/utils.py calls hashlib.md5(),
which fails. RHEL requires hashlib use the
usedforsecurity=False option.

Fixes #187.