### PR TITLE
Fixed segfault in Seatrac Task because ticket pointer is not initialized

### DIFF
--- a/src/Transports/Seatrac/Task.cpp
+++ b/src/Transports/Seatrac/Task.cpp
@@ -181,7 +181,8 @@ namespace Transports
         m_pre_detected(false),
         m_stop_comms(false),
         m_usbl_receiver(false),
-        m_tstamp(0)
+        m_tstamp(0), 
+        m_ticket(NULL)
       {
         // Define configuration parameters.
         paramActive(Tasks::Parameter::SCOPE_MANEUVER,


### PR DESCRIPTION
Fixed segfault in Seatrac Task because ticket pointer is not initialized.

The src/Trasnports/Seatrac/Task.cpp has a member variable Ticket* m_ticket.
However, that point is not initialized to NULL. This causes a segfault on
some systems in sendTxStatus(...) because the ticket is used without being
initialized. Normally, the check for NULL in clearTicket(...) would have
prevented this from happening.

Fixes #189.