### PR TITLE
Bugfix/do not call request activation methods if already act ip

### DIFF
--- a/src/DUNE/Entities/StatefulEntity.cpp
+++ b/src/DUNE/Entities/StatefulEntity.cpp
@@ -77,7 +77,7 @@ namespace DUNE
       dispatch(m_act_state);
     }
 
-    void
+    bool
     StatefulEntity::requestActivation(void)
     {
       if (m_act_state.state != IMC::EntityActivationState::EAS_INACTIVE)
@@ -99,15 +99,16 @@ namespace DUNE
         }
 
         dispatch(m_act_state);
-        return;
+        return false;
       }
 
       m_next_act_state = NAS_SAME;
       m_act_state.state = IMC::EntityActivationState::EAS_ACT_IP;
       dispatch(m_act_state);
+      return true;
     }
 
-    void
+    bool
     StatefulEntity::requestDeactivation(void)
     {
       if (m_act_state.state != IMC::EntityActivationState::EAS_ACTIVE)
@@ -129,12 +130,13 @@ namespace DUNE
         }
 
         dispatch(m_act_state);
-        return;
+        return false;
       }
 
       m_next_act_state = NAS_SAME;
       m_act_state.state = IMC::EntityActivationState::EAS_DEACT_IP;
       dispatch(m_act_state);
+      return true;
     }
 
     void

--- a/src/DUNE/Entities/StatefulEntity.hpp
+++ b/src/DUNE/Entities/StatefulEntity.hpp
@@ -142,11 +142,11 @@ namespace DUNE
       }
 
       //! Request entity activation
-      void
+      bool
       requestActivation(void);
 
       //! Request entity deactivation
-      void
+      bool
       requestDeactivation(void);
 
       //! Mark the activation as unsuccessful.

--- a/src/DUNE/Tasks/Task.cpp
+++ b/src/DUNE/Tasks/Task.cpp
@@ -274,9 +274,8 @@ namespace DUNE
     Task::requestActivation(void)
     {
       spew("request activation");
-      m_entity->requestActivation();
 
-      if (m_entity->isActivating())
+      if (m_entity->requestActivation())
       {
         spew("calling on request activation");
         onRequestActivation();
@@ -314,9 +313,8 @@ namespace DUNE
     Task::requestDeactivation(void)
     {
       spew("request deactivation");
-      m_entity->requestDeactivation();
 
-      if (m_entity->isDeactivating())
+      if (m_entity->requestDeactivation())
       {
         spew("calling on request deactivation");
         onRequestDeactivation();


### PR DESCRIPTION
If derived tasks execute multiple requests, onRequest methods are called repeatedly and this should be prevented at task base class level.