### PR TITLE
Control/UAV/Ardupilot: Ensure hae_offset is not reset upon losing GPS fix

### DIFF
--- a/src/Control/UAV/Ardupilot/Task.cpp
+++ b/src/Control/UAV/Ardupilot/Task.cpp
@@ -1811,12 +1811,16 @@ namespace Control
               m_hae_offset = wmm.height(m_lat, m_lon);
               m_reboot = false;
               m_offset_st = true;
+              debug("Height offset at %3.10f/%3.10f is %f", Angles::degrees(m_lat), Angles::degrees(m_lon), m_hae_offset);
             }
           }
-          else
+          else if (m_args.convert_msl == false)
           {
             m_hae_offset = 0;
+            m_offset_st = false;
+            debug("Height offset set to zero (convert?%d, gpstype: %d)",m_args.convert_msl, m_fix.type);
           }
+          //else: m_args.convert_msl is true, but we do not have/have lost GPS: leave m_hae_offset as is
 
           m_estate.lat = m_lat;
           m_estate.lon = m_lon;


### PR DESCRIPTION
Previously, m_hae_offset would be reset to zero if a single GpsFix message indicated poor Gps conditions, and since it did not reset the m_offset_st flag, it would remain zero forever, causing the "WGS84 height" in DUNE to be equal to MSL. Now, the offset is only set to zero if the conversion flag is false, in which case m_offset_st is also reset to false. If Gps is lost, the old value of the offset is used.

The debug-printouts are of course not needed, but proved useful when debugging this.

Hopefully this is the end of the AP/DUNE height issues. This has been tested in flight.