### PR TITLE
Fixes in DUNE/Maneuvers/StationKeep

### DIFF
--- a/src/DUNE/Maneuvers/StationKeep.cpp
+++ b/src/DUNE/Maneuvers/StationKeep.cpp
@@ -41,6 +41,8 @@ namespace DUNE
   {
     //! Factor for the radius to consider traveling at the surface
     static const float c_surface_factor = 2.5f;
+    //! Limits the rate at which DesiredPath messages are dispatched.
+    static const double c_dpath_dispatch_period = 1.0;
 
     //! Default constructor.
     StationKeep::StationKeep(const IMC::StationKeeping* maneuver, Maneuvers::Maneuver* task,
@@ -113,6 +115,8 @@ namespace DUNE
       {
         m_task->dispatch(m_path);
       }
+
+      m_last_dpath_dispatch = DUNE::Time::Clock::get();
     }
 
     void
@@ -169,10 +173,27 @@ namespace DUNE
       switch (m_sks)
       {
         case ST_OFF_STATION:
-          if (pcs->flags & IMC::PathControlState::FL_NEAR && range < m_radius)
+          if (pcs->flags & IMC::PathControlState::FL_NEAR)
           {
-            stopMoving(range);
-            m_sks = ST_ON_STATION;
+            if (range < m_radius)
+            {
+              stopMoving(range);
+              m_sks = ST_ON_STATION;
+            }
+            else
+            {
+              const double now = DUNE::Time::Clock::get();
+
+              if (now >= m_last_dpath_dispatch + c_dpath_dispatch_period)
+              {
+                m_task->debug("FL_NEAR is set but range is %.2f >= %.2f",
+                              range,
+                              m_radius);
+
+                m_task->dispatch(m_path);
+                m_last_dpath_dispatch = now;
+              }
+            }
           }
           break;
         default:

--- a/src/DUNE/Maneuvers/StationKeep.cpp
+++ b/src/DUNE/Maneuvers/StationKeep.cpp
@@ -72,6 +72,7 @@ namespace DUNE
       m_path.end_z_units = z_units;
       m_path.speed = speed;
       m_path.speed_units = speed_units;
+      m_path.flags |= IMC::DesiredPath::FL_DIRECT;
     }
 
     double

--- a/src/DUNE/Maneuvers/StationKeep.hpp
+++ b/src/DUNE/Maneuvers/StationKeep.hpp
@@ -126,6 +126,8 @@ namespace DUNE
       double m_radius;
       //! Current state of the state machine
       StationState m_sks;
+      //! Time of last DesiredPath dispatch.
+      double m_last_dpath_dispatch;
     };
   }
 }


### PR DESCRIPTION
These patches fix two bugs in the `StationKeep` class which cause `PathController` to timeout during execution of the `StationKeeping` maneuver.

* 6bc18fe - Set the `FL_DIRECT` flag in the `DesiredPath` message dispatched by the `StationKeeping` maneuver. This forces the `PathController` to use the estimated position of the vehicle as the path starting point. Otherwise the `PathController` will sometimes set the endpoint of the previously received path as the starting point for the new path, which in the case of `StationKeeping` leads to a path with identical start and end points.

* 6ec7dd4 - `PathControlState` messages with `FL_NEAR` set must not be ignored, or else `PathController` will timeout while waiting for a new reference. The `DesiredPath` message must be re-sent. The rate at which it is re-sent is controlled by `c_dpath_dispatch_period` (should this be a configuration parameter?).