### PR TITLE
Supervisors/Vehicle: also show who requested an abort

### DIFF
--- a/src/Supervisors/Vehicle/Task.cpp
+++ b/src/Supervisors/Vehicle/Task.cpp
@@ -243,7 +243,7 @@ namespace Supervisors
         if (msg->getDestination() != getSystemId())
           return;
 
-        m_vs.last_error = DTR("got abort request");
+        m_vs.last_error = DTR("got abort request from ") + resolveEntity(msg->getSourceEntity());
         m_vs.last_error_time = Clock::getSinceEpoch();
         err("%s", m_vs.last_error.c_str());
 


### PR DESCRIPTION
Small enhancement that might be valued by others than me.

My use case: I have multiple tasks that monitor different aspects of a landing maneuver, and each of them will issue an Abort if their abort criteria is fulfilled.