### PR TITLE
Various fixes/enhancements to FollowReference/UAV

### DIFF
--- a/src/Maneuver/FollowReference/UAV/Task.cpp
+++ b/src/Maneuver/FollowReference/UAV/Task.cpp
@@ -99,7 +99,8 @@ namespace Maneuver
 
           bindToManeuver<Task, IMC::FollowReference>();
           bind<IMC::Reference>(this);
-          bind<IMC::EstimatedState>(this);
+          //Always consume EstimatedState, as it is needed by consume(FollowReference)
+          bind<IMC::EstimatedState>(this,true);
         }
 
         void

--- a/src/Maneuver/FollowReference/UAV/Task.cpp
+++ b/src/Maneuver/FollowReference/UAV/Task.cpp
@@ -463,7 +463,7 @@ namespace Maneuver
         offlineOrWaiting(void)
         {
           return ((m_fref_state.state & IMC::FollowRefState::FR_TIMEOUT)
-                  && (m_fref_state.state & IMC::FollowRefState::FR_WAIT));
+                  || (m_fref_state.state & IMC::FollowRefState::FR_WAIT));
         }
 
         void

--- a/src/Maneuver/FollowReference/UAV/Task.cpp
+++ b/src/Maneuver/FollowReference/UAV/Task.cpp
@@ -441,8 +441,8 @@ namespace Maneuver
           if (delta > m_spec.timeout  && isActive())
           {
             m_fref_state.state = IMC::FollowRefState::FR_TIMEOUT;
-            signalError("reference source timed out");
             dispatch(m_fref_state);
+            signalError("reference source timed out");
           }
         }
 


### PR DESCRIPTION
9d0a5e3 fixes what seems to be a typo (&& instead of ||)

f41de2d reorders signalError and a dispatch, as the message was never dispatched

The two other commits are more of a design question, I guess, but the current master code is ambigous: 

- currently, we are waiting for a FollowReference message, and are not accepting any other messages.
- once the FollowReference is activated, the first DesiredPath is dispatched. But since we have not received any EstimatedState or Reference yet, lat/lon/height is zero.

There are two ways to fix this:

1. always consume EstimatedState (9233527). Then, upon FollowReference activation, the current position is dispatched as lat/lon/height. This is in my eyes less than ideal, which is why I suggest
2. always consume EstimatedState and Reference (9233527 and b59f972). Store Reference as it is received. Upon FollowReference activation, check if the previous Reference came from an authorized source. If it did; use it, if not; use EstimatedState.

Tested in flight