### PR TITLE
Adds support for variable size numerical container (new IMC type)

### DIFF
--- a/programs/generators/imc_code.py
+++ b/programs/generators/imc_code.py
@@ -339,7 +339,7 @@ class Message:
         for field in self._node.findall('field'):
             type = field.get('type')
             abbrev = get_name(field)
-            if type == 'plaintext' or type == 'rawdata':
+            if type in ['plaintext', 'rawdata', 'vector']:
                 size.append('IMC::getSerializationSize(%s)' % abbrev)
             elif type == 'message' or type == 'message-list':
                 size.append(abbrev + '.getSerializationSize()')

--- a/programs/generators/imc_code.py
+++ b/programs/generators/imc_code.py
@@ -38,10 +38,13 @@ CONST_NULL_ID = 65535
 def get_cxx_type(field_node):
     type = field_node.get('type')
     msg_type = field_node.get('message-type', 'Message')
+
     if type == 'plaintext':
         return 'std::string'
     elif type == 'rawdata':
         return 'std::vector<char>'
+    elif type == 'vector':
+        return 'std::vector<%s>' % field_node.get('vector-type', 'uint8_t')
     elif type == 'message':
         return 'InlineMessage<%s>' % msg_type
     elif type == 'message-list':
@@ -51,15 +54,7 @@ def get_cxx_type(field_node):
 
 def is_fixed(field_node):
     type = field_node.get('type')
-    if type == 'message':
-        return False
-    elif type == 'plaintext':
-        return False
-    elif type == 'rawdata':
-        return False
-    elif type == 'message-list':
-        return False
-    return True
+    return type not in ['message', 'plaintext', 'rawdata', 'vector', 'message-list']
 
 def get_clear(field_node):
     rv = get_name(field_node)

--- a/src/DUNE/IMC/Serialization.hpp
+++ b/src/DUNE/IMC/Serialization.hpp
@@ -129,7 +129,7 @@ namespace DUNE
       std::memcpy(bfr, &s, sizeof(s));
       bfr += sizeof(s);
       if (s > 0)
-        std::copy(t.begin(), t.end(), bfr);
+        std::memcpy(bfr, &t[0], s*sizeof(Type));
       return s*sizeof(Type) + 2;
     }
 


### PR DESCRIPTION
This adds support for the variable sized numerical container type in IMC ([pull request](https://github.com/LSTS/imc/pull/28)). 

Changes include

- Serialization
- Deserialization
- JSON output (ex: "vectorint8": [-79, 118, -119, 110, 0, -116, 94, 34, -62])
- IMC definitions generation (std::vector<vector-type>)
- IMC test generation (now also outputs JSON for each message being parsed)

The JSON implementation required some refactoring to avoid changing the behavior for rawdata fields (std::vector<char>), due to the vector template.

Example message
```xml
<message id="3000" name="Vector Test" abbrev="VectorTest" source="vehicle">
    <field name="VUInt8" abbrev="VUInt8" type="vector" vector-type="uint8_t"/>
    <field name="VUInt16" abbrev="VUInt16" type="vector" vector-type="uint16_t"/>
    <field name="VUInt32" abbrev="VUInt32" type="vector" vector-type="uint32_t"/>
    <field name="VUInt64" abbrev="VUInt64" type="vector" vector-type="uint64_t"/>
    <field name="VInt8" abbrev="VInt8" type="vector" vector-type="int8_t"/>
    <field name="VInt16" abbrev="VInt16" type="vector" vector-type="int16_t"/>
    <field name="VInt32" abbrev="VInt32" type="vector" vector-type="int32_t"/>
    <field name="VInt64" abbrev="VInt64" type="vector" vector-type="int64_t"/>
    <field name="VFp32" abbrev="VFp32" type="vector" vector-type="fp32_t"/>
    <field name="VFp64" abbrev="VFp64" type="vector" vector-type="fp64_t"/>
</message>
```
Example JSON output from test_IMC.cpp below
```JSON
{
  "abbrev": "VectorTest",
  "timestamp": "0.240822519036",
  "src": "13178",
  "src_ent": "146",
  "dst": "47524",
  "dst_ent": "0",
  "vuint8": [221, 156, 136],
  "vuint16": [37448, 57766],
  "vuint32": [],
  "vuint64": [534796193650451416, 13968894843252329076, 12528655269392993852, 1382089629888762297],
  "vint8": [-79, 118, -119, 110, 0, -116, 94, 34, -62],
  "vint16": [13679, -17283, -256, -11933, -16986, -18199, 7330, 15935, -27224],
  "vint32": [1133517027, 1100964103, 622779471, 2130846750, -1860246269, -586430523, -1464696739, 985052755, 1244632231],
  "vint64": [-3698527484349829534, 3759153311435130465, -3979969022960290610, -3921901367132325590, -1239570279959320365, 1434379472680176510, -4609213349486860242],
  "vfp32": [0.773889362812, 0.39666813612, 0.895049273968],
  "vfp64": [0.319782122474, 0.0669650237304, 0.601433012171]
}
```
