### PR TITLE
Plan/Engine: Set plan_id before dispatching pcs when starting new plan

### DIFF
--- a/src/Plan/Engine/Task.cpp
+++ b/src/Plan/Engine/Task.cpp
@@ -845,6 +845,9 @@ namespace Plan
       {
         bool stopped = stopPlan(true);
 
+        // Change plan_id before dispatching first PlanControlState
+        m_pcs.plan_id = plan_id;
+
         changeMode(IMC::PlanControlState::PCS_INITIALIZING,
                    DTR("plan initializing: ") + plan_id, TYPE_INF);
 

--- a/src/Plan/Engine/Task.cpp
+++ b/src/Plan/Engine/Task.cpp
@@ -845,8 +845,10 @@ namespace Plan
       {
         bool stopped = stopPlan(true);
 
-        // Change plan_id before dispatching first PlanControlState
+        // Reset plan state before dispatching first pcs
         m_pcs.plan_id = plan_id;
+        m_pcs.plan_eta = -1;
+        m_pcs.plan_progress = -1;
 
         changeMode(IMC::PlanControlState::PCS_INITIALIZING,
                    DTR("plan initializing: ") + plan_id, TYPE_INF);


### PR DESCRIPTION
The call to changeMode dispatches a PlanControlState message with state initializing, but does not set the new plan_id. This sets the plan_id before the call to changeMode when starting a new plan to avoid dispatching a PlanControlState message with the name of the previous plan and initializing. See the attached Neptus screenshot where the plan test2 is started during the execution of test1.

![DUNE_PlanEngine_pcs](https://user-images.githubusercontent.com/8938387/67666062-4a9b0100-f96b-11e9-8659-6ff579d5bec7.png)
