### PR TITLE
Feature/clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,38 +1,21 @@
 ---
-Language: Cpp
-AccessModifierOffset: -2
-AlignEscapedNewlinesLeft: false
-AlwaysBreakAfterDefinitionReturnType: All
+BasedOnStyle:  LLVM
+AllowShortFunctionsOnASingleLine: Inline
+AlwaysBreakAfterReturnType: AllDefinitions
 BinPackArguments: true
 BinPackParameters: true
-BraceWrapping:
-  AfterClass: true
-  AfterControlStatement: true
-  AfterEnum: true
-  AfterFunction: true
-  AfterNamespace: true
-  AfterObjCDeclaration: true
-  AfterStruct: true
-  AfterUnion: true
-  BeforeCatch: true
-  BeforeElse: true
-  IndentBraces: false
-BreakBeforeBinaryOperators: All
-BreakBeforeBraces: Custom
-BreakBeforeTernaryOperators: true
-ColumnLimit: 80
-ConstructorInitializerIndentWidth: 0
-ContinuationIndentWidth: 0
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Allman
+BreakConstructorInitializers: AfterColon
+ColumnLimit: 100
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 2
+Cpp11BracedListStyle: false
 IndentCaseLabels: true
 NamespaceIndentation: All
-PenaltyBreakBeforeFirstCallParameter: 100
 PointerAlignment: Left
-SortIncludes: false
-SpaceAfterCStyleCast: true
-SpaceBeforeParens: ControlStatements
-SpacesBeforeTrailingComments: 1
-UseTab: Never
-AlignAfterOpenBracket: Align
-Cpp11BracedListStyle: false
-AlignConsecutiveAssignments: false
+SpacesBeforeTrailingComments: 2
+SpaceAfterTemplateKeyword: false
+AlignEscapedNewlines: Left
+FixNamespaceComments: false
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,21 @@
+---
+BasedOnStyle:  LLVM
+AllowShortFunctionsOnASingleLine: Inline
+AlwaysBreakAfterReturnType: AllDefinitions
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Allman
+BreakConstructorInitializers: AfterColon
+ColumnLimit: 80
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 2
+Cpp11BracedListStyle: false
+IndentCaseLabels: true
+NamespaceIndentation: All
+PointerAlignment: Left
+SpacesBeforeTrailingComments: 2
+SpaceAfterTemplateKeyword: false
+AlignEscapedNewlines: Left
+FixNamespaceComments: false
+...

--- a/.clang-format
+++ b/.clang-format
@@ -1,21 +1,38 @@
 ---
-BasedOnStyle:  LLVM
-AllowShortFunctionsOnASingleLine: Inline
-AlwaysBreakAfterReturnType: AllDefinitions
+Language: Cpp
+AccessModifierOffset: -2
+AlignEscapedNewlinesLeft: false
+AlwaysBreakAfterDefinitionReturnType: All
 BinPackArguments: true
 BinPackParameters: true
-BreakBeforeBinaryOperators: NonAssignment
-BreakBeforeBraces: Allman
-BreakConstructorInitializers: AfterColon
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: true
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: true
+  AfterStruct: true
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
 ColumnLimit: 80
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
-ConstructorInitializerIndentWidth: 2
-Cpp11BracedListStyle: false
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 0
 IndentCaseLabels: true
 NamespaceIndentation: All
+PenaltyBreakBeforeFirstCallParameter: 100
 PointerAlignment: Left
-SpacesBeforeTrailingComments: 2
-SpaceAfterTemplateKeyword: false
-AlignEscapedNewlines: Left
-FixNamespaceComments: false
+SortIncludes: false
+SpaceAfterCStyleCast: true
+SpaceBeforeParens: ControlStatements
+SpacesBeforeTrailingComments: 1
+UseTab: Never
+AlignAfterOpenBracket: Align
+Cpp11BracedListStyle: false
+AlignConsecutiveAssignments: false
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -18,7 +18,7 @@ PointerAlignment: Left
 SpaceBeforeCtorInitializerColon: false
 SpaceBeforeInheritanceColon: false
 SpacesBeforeTrailingComments: 2
-SpaceAfterTemplateKeyword: false
+SpaceAfterTemplateKeyword: true
 AlignEscapedNewlines: Left
 FixNamespaceComments: false
 ContinuationIndentWidth: 2

--- a/.clang-format
+++ b/.clang-format
@@ -1,11 +1,12 @@
 ---
-BasedOnStyle:  LLVM
-AllowShortFunctionsOnASingleLine: Inline
-AlwaysBreakAfterReturnType: AllDefinitions
+Language: Cpp
+BasedOnStyle: LLVM
+AllowShortFunctionsOnASingleLine: None
+AlwaysBreakAfterReturnType: All
 BinPackArguments: true
 BinPackParameters: true
 BreakBeforeBinaryOperators: NonAssignment
-BreakBeforeBraces: Allman
+BreakBeforeBraces: Custom
 BreakConstructorInitializers: AfterColon
 ColumnLimit: 100
 PackConstructorInitializers: Never
@@ -21,4 +22,25 @@ SpaceAfterTemplateKeyword: false
 AlignEscapedNewlines: Left
 FixNamespaceComments: false
 ContinuationIndentWidth: 2
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: false
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+SpaceInEmptyBlock: true
+UseTab: Never
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -8,14 +8,17 @@ BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeBraces: Allman
 BreakConstructorInitializers: AfterColon
 ColumnLimit: 100
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
+PackConstructorInitializers: Never
 ConstructorInitializerIndentWidth: 2
 Cpp11BracedListStyle: false
 IndentCaseLabels: true
 NamespaceIndentation: All
 PointerAlignment: Left
+SpaceBeforeCtorInitializerColon: false
+SpaceBeforeInheritanceColon: false
 SpacesBeforeTrailingComments: 2
 SpaceAfterTemplateKeyword: false
 AlignEscapedNewlines: Left
 FixNamespaceComments: false
+ContinuationIndentWidth: 2
 ...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -429,3 +429,37 @@ endif(TESTS)
 #                                CDash                                   #
 ##########################################################################
 include(Dart)
+
+##########################################################################
+#                             CLANG-FORMAT                               #
+##########################################################################
+find_program(
+  CLANG_FORMAT_EXECUTABLE
+  NAMES "clang-format"
+  DOC "Path to clang-format executable"
+  )
+if(NOT CLANG_FORMAT_EXECUTABLE)
+  message(STATUS "clang-format not found.")
+else()
+  message(STATUS "clang-format found: ${CLANG_FORMAT_EXECUTABLE}")
+  set(DO_CLANG_FORMAT "${CLANG_FORMAT_EXECUTABLE}" "-i -style=file")
+endif()
+
+if(CLANG_FORMAT_EXECUTABLE)
+  add_custom_target(
+    clang-format-core-sources
+    COMMAND ${CLANG_FORMAT_EXE} -i -style=file ${DUNE_CORE_HEADERS} ${DUNE_CORE_SOURCES}
+  )
+  add_custom_target(
+    clang-format-programs
+    COMMAND ${CLANG_FORMAT_EXE} -i -style=file ${programs}
+  )
+  add_custom_target(
+    clang-format-tests
+    COMMAND ${CLANG_FORMAT_EXE} -i -style=file ${DUNE_TESTS_SOURCES}
+  )
+  add_custom_target(
+    clang-format-tasks
+    COMMAND ${CLANG_FORMAT_EXE} -i -style=file ${ALL_TASK_SOURCES} ${ALL_TASK_HEADERS}
+  )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,24 +442,24 @@ if(NOT CLANG_FORMAT_EXECUTABLE)
   message(STATUS "clang-format not found.")
 else()
   message(STATUS "clang-format found: ${CLANG_FORMAT_EXECUTABLE}")
-  set(DO_CLANG_FORMAT "${CLANG_FORMAT_EXECUTABLE}" "-i -style=file")
+  set(DO_CLANG_FORMAT "${CLANG_FORMAT_EXECUTABLE}" -i -style=file)
 endif()
 
 if(CLANG_FORMAT_EXECUTABLE)
   add_custom_target(
     clang-format-core-sources
-    COMMAND ${CLANG_FORMAT_EXE} -i -style=file ${DUNE_CORE_HEADERS} ${DUNE_CORE_SOURCES}
+    COMMAND "${CLANG_FORMAT_EXECUTABLE}" -i -style=file ${DUNE_CORE_HEADERS} ${DUNE_CORE_SOURCES}
   )
   add_custom_target(
     clang-format-programs
-    COMMAND ${CLANG_FORMAT_EXE} -i -style=file ${programs}
+    COMMAND "${CLANG_FORMAT_EXECUTABLE}" -i -style=file ${programs}
   )
   add_custom_target(
     clang-format-tests
-    COMMAND ${CLANG_FORMAT_EXE} -i -style=file ${DUNE_TESTS_SOURCES}
+    COMMAND "${CLANG_FORMAT_EXECUTABLE}" -i -style=file ${DUNE_TESTS_SOURCES}
   )
   add_custom_target(
     clang-format-tasks
-    COMMAND ${CLANG_FORMAT_EXE} -i -style=file ${ALL_TASK_SOURCES} ${ALL_TASK_HEADERS}
+    COMMAND "${CLANG_FORMAT_EXECUTABLE}" -i -style=file ${ALL_TASK_SOURCES} ${ALL_TASK_HEADERS}
   )
 endif()

--- a/cmake/Tasks.cmake
+++ b/cmake/Tasks.cmake
@@ -27,6 +27,10 @@
 # Author: Ricardo Martins                                                  #
 ############################################################################
 
+set(ALL_TASK_SOURCES)
+set(ALL_TASK_HEADERS)
+
+
 macro(dune_add_task root_folder task)
   string(REPLACE "/Task.cmake" "" path ${task})
 
@@ -104,6 +108,9 @@ macro(dune_add_task root_folder task)
     if(NOT TASK_HEADERS)
       file(GLOB TASK_HEADERS ${root_folder}/${path}/*.hpp)
     endif(NOT TASK_HEADERS)
+
+    set(ALL_TASK_SOURCES ${ALL_TASK_SOURCES} ${TASK_SOURCES})
+    set(ALL_TASK_HEADERS ${ALL_TASK_HEADERS} ${TASK_HEADERS})
 
     if(TASK_PROGRAM)
       foreach(task_main_source ${TASK_PROGRAM})

--- a/programs/scripts/dune-clang-format.sh
+++ b/programs/scripts/dune-clang-format.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+############################################################################
+# Copyright 2007-2019 Universidade do Porto - Faculdade de Engenharia      #
+# Laboratório de Sistemas e Tecnologia Subaquática (LSTS)                  #
+############################################################################
+# This file is part of DUNE: Unified Navigation Environment.               #
+#                                                                          #
+# Commercial Licence Usage                                                 #
+# Licencees holding valid commercial DUNE licences may use this file in    #
+# accordance with the commercial licence agreement provided with the       #
+# Software or, alternatively, in accordance with the terms contained in a  #
+# written agreement between you and Faculdade de Engenharia da             #
+# Universidade do Porto. For licensing terms, conditions, and further      #
+# information contact lsts@fe.up.pt.                                       #
+#                                                                          #
+# Modified European Union Public Licence - EUPL v.1.1 Usage                #
+# Alternatively, this file may be used under the terms of the Modified     #
+# EUPL, Version 1.1 only (the "Licence"), appearing in the file LICENCE.md #
+# included in the packaging of this file. You may not use this work        #
+# except in compliance with the Licence. Unless required by applicable     #
+# law or agreed to in writing, software distributed under the Licence is   #
+# distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF     #
+# ANY KIND, either express or implied. See the Licence for the specific    #
+# language governing permissions and limitations at                        #
+# https://github.com/LSTS/dune/blob/master/LICENCE.md and                  #
+# http://ec.europa.eu/idabc/eupl.html.                                     #
+############################################################################
+# Author: Jose Pinto                                                       #
+############################################################################
+
+# This script can be used to format all committed source files using 
+# clang-format. It can also be added used as .git/hooks/pre-commit script
+
+format_file() {
+  file="${1}"
+  if [ -f $file ]; then
+    clang-format -i ${1}
+    git add ${1}
+  fi
+}
+
+case "${1}" in
+  --help )
+    echo "Runs clang-format on locally committed source files"
+    ;;
+  * )
+    for file in `git diff-index --cached --name-only HEAD | grep -iE '\.(c|cpp|h|hpp)$' ` ; do
+	    echo "Applying clang-format to ${file}..."
+      format_file "${file}"
+    done
+    ;;
+esac


### PR DESCRIPTION
* Added .clang-format that can be used directly from most IDEs (https://github.com/andrewseidl/githook-clang-format).
* Also added a script under programs/scripts that will apply this format to any locally commited source files (can be also be used as a git pre-commit hook).
* CMakeLists also has targets to reformat the entire source (if ever this will be needed).