### PR TITLE
DUNE/Hardware/SerialPort: add read-only option

### DIFF
--- a/src/DUNE/Hardware/SerialPort.cpp
+++ b/src/DUNE/Hardware/SerialPort.cpp
@@ -188,10 +188,17 @@ namespace DUNE
       return devs;
     }
 
-    SerialPort::SerialPort(const std::string& device, int baudrate, Parity parity, StopBits stopbits, DataBits databits, bool block)
+    SerialPort::SerialPort(const std::string& device, int baudrate, Parity parity, StopBits stopbits, DataBits databits, bool block, bool readonly)
     {
 #if defined(DUNE_OS_POSIX)
-      m_handle = open(device.c_str(), O_RDWR | O_NOCTTY | O_NONBLOCK);
+      if(readonly)
+      {
+        m_handle = open(device.c_str(), O_RDONLY | O_NOCTTY | O_NONBLOCK);
+      }
+      else
+      {
+        m_handle = open(device.c_str(), O_RDWR | O_NOCTTY | O_NONBLOCK);
+      }
 
       if (m_handle == -1)
       {

--- a/src/DUNE/Hardware/SerialPort.hpp
+++ b/src/DUNE/Hardware/SerialPort.hpp
@@ -127,7 +127,7 @@ namespace DUNE
       //! @param databits number of data bits.
       //! @param block false enable non-blocking I/O.
       //! @throw SerialPortError.
-      SerialPort(const std::string& device, int baudrate = 38400, Parity parity = SP_PARITY_NONE, StopBits stopbits = SP_STOPBITS_1, DataBits databits = SP_DATABITS_8, bool block = false);
+      SerialPort(const std::string& device, int baudrate = 38400, Parity parity = SP_PARITY_NONE, StopBits stopbits = SP_STOPBITS_1, DataBits databits = SP_DATABITS_8, bool block = false, bool readonly = false);
 
       //! Serial port destructor.
       ~SerialPort(void);


### PR DESCRIPTION
Small PR to make it possible to use the SerialPort interface in read-only mode. Work by Artur Zolich.

Also have some code that makes use of this in SerialOverTCP, but that code is a bit "brute force". Just mentioning it, in case someone is interested.

The use-case was: two UHF radios on the ground, and wanted to be absolutely sure that only one of them was sending data.