### PR TITLE
Sensors/GPS: Add Novatel SBAS support

### DIFF
--- a/etc/development/novatel.ini
+++ b/etc/development/novatel.ini
@@ -1,0 +1,39 @@
+############################################################################
+# Copyright 2007-2021 Universidade do Porto - Faculdade de Engenharia      #
+# Laboratório de Sistemas e Tecnologia Subaquática (LSTS)                  #
+############################################################################
+# This file is part of DUNE: Unified Navigation Environment.               #
+#                                                                          #
+# Commercial Licence Usage                                                 #
+# Licencees holding valid commercial DUNE licences may use this file in    #
+# accordance with the commercial licence agreement provided with the       #
+# Software or, alternatively, in accordance with the terms contained in a  #
+# written agreement between you and Faculdade de Engenharia da             #
+# Universidade do Porto. For licensing terms, conditions, and further      #
+# information contact lsts@fe.up.pt.                                       #
+#                                                                          #
+# Modified European Union Public Licence - EUPL v.1.1 Usage                #
+# Alternatively, this file may be used under the terms of the Modified     #
+# EUPL, Version 1.1 only (the "Licence"), appearing in the file LICENCE.md #
+# included in the packaging of this file. You may not use this work        #
+# except in compliance with the Licence. Unless required by applicable     #
+# law or agreed to in writing, software distributed under the Licence is   #
+# distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF     #
+# ANY KIND, either express or implied. See the Licence for the specific    #
+# language governing permissions and limitations at                        #
+# https://github.com/LSTS/dune/blob/master/LICENCE.md and                  #
+# http://ec.europa.eu/idabc/eupl.html.                                     #
+############################################################################
+# Author: Ricardo Falcão                                                  #
+############################################################################
+
+[Require ../common/transports.ini]
+
+[Sensors.GPS]
+Enabled                                 = Always
+Debug Level                             = Trace
+Entity Label                            = GPS
+Serial Port - Device                    = /dev/ttyUSB0
+Serial Port - Baud Rate                 = 115200
+Novatel                                 = true
+Sentence Order                          = GPZDA, GPGGA, GPRMC, GPVTG

--- a/etc/development/novatel.ini
+++ b/etc/development/novatel.ini
@@ -35,5 +35,18 @@ Debug Level                             = Trace
 Entity Label                            = GPS
 Serial Port - Device                    = /dev/ttyUSB0
 Serial Port - Baud Rate                 = 115200
-Novatel                                 = true
+Initialization String 0 - Command       = UNLOGALL THISPORT_ALL\r\n
+Initialization String 1 - Command       = LOG GPZDA ONTIME 1\r\n
+Initialization String 2 - Command       = LOG GPGGA ONTIME 1\r\n
+Initialization String 3 - Command       = LOG GPRMC ONTIME 1\r\n
+Initialization String 4 - Command       = LOG GPVTG ONTIME 1\r\n
+Initialization String 5 - Command       = LOG BESTPOSA ONTIME 1\r\n
+Initialization String 6 - Command       = LOG RAWEPHEMA ONNEW\r\n
+Initialization String 7 - Command       = LOG RANGEA ONTIME 1\r\n
 Sentence Order                          = GPZDA, GPGGA, GPRMC, GPVTG
+Novatel SBAS                            = true
+
+[Transports.Logging]
+Enabled = Always
+Entity Label = Logger
+Transports = GpsFix,EulerAngles,AngularVelocity,LogBookEntry,DevDataText

--- a/src/Sensors/GPS/Task.cpp
+++ b/src/Sensors/GPS/Task.cpp
@@ -84,8 +84,8 @@ namespace Sensors
       std::string init_rpls[c_max_init_cmds];
       //! Power channels.
       std::vector<std::string> pwr_channels;
-      //! Enable novatel features.
-      bool novatel;
+      //! Enable novatel sbas mode.
+      bool novatelSbas;
     };
 
     struct Task: public Tasks::Task
@@ -154,9 +154,9 @@ namespace Sensors
           .defaultValue("");
         }
 
-        param("Novatel", m_args.novatel)
+        param("Novatel SBAS", m_args.novatelSbas)
         .defaultValue("false")
-        .description("Enable novatel features");
+        .description("Enable novatel sbas mode");
 
         // Initialize messages.
         clearMessages();
@@ -228,9 +228,12 @@ namespace Sensors
       void
       onResourceInitialization(void)
       {
-        if (m_args.novatel)
+        if (m_args.novatelSbas)
         {
-          trace(DTR("enabling NOVATEL mode."));
+          trace(DTR("enabling NOVATEL SBAS mode."));
+
+          std::string cmd = String::unescape("SBASCONTROL ENABLE AUTO\r\n");
+          m_handle->writeString(cmd.c_str());
         }
 
         for (unsigned i = 0; i < c_max_init_cmds; ++i)
@@ -592,7 +595,7 @@ namespace Sensors
           m_fix.validity |= IMC::GpsFix::GFV_VALID_POS;
         }
 
-        if (m_args.novatel)
+        if (m_args.novatelSbas)
         {
           static bool sbas_alert = false;
 


### PR DESCRIPTION
This PR modifies the current GPS task to take advantage of the SBAS funcionality provided out of the box in most Novatel GPS receivers. This is configured through a parameter called `Novatel SBAS`.

Included is also an example configuration file, which was successfully tested against the Novatel FlexPak6 (OEM6).