### PR TITLE
CI: Add GitHub Actions workflow for Linux build and test.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,25 @@
+name: linux
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Prepare
+      run: cmake -B ${{github.workspace}}/build -DDEBUG=1 -DTESTS=1
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --target Experimental
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest


### PR DESCRIPTION
.travis-ci.yml is no longer working
travis-ci.org was moved to travis-ci.com but I could not enable.

Either way, GitHub Actions is quite a handy way to add CI/CD here