### PR TITLE
Transports/Replay: added argument list option with authorized Source …

### DIFF
--- a/etc/testing/replays/sgnav-replay.ini
+++ b/etc/testing/replays/sgnav-replay.ini
@@ -89,6 +89,9 @@ Replay Messages = AngularVelocity,
                   VehicleMedium,
                   WaterVelocity
 
+# List of messages that are only replayed if coming from an accepted source entity
+Filter By Entities = GpsFix:GPS
+
 # NOTE: Optionally set the starting replay file
 # Otherwise use: 'sendmsg 127.0.0.1 6002 ReplayControl 0 <log path>/Data.lsf'
-Load At Start   = /home/luis/workspace/logs/Navigation/OGs/2021-04-23_apdl/logs/lauv-noptilus-3/20210428/142022_navigation_test_fig8/Data.lsf
+#Load At Start   = /home/luis/workspace/logs/Navigation/OGs/2021-04-23_apdl/logs/lauv-noptilus-3/20210428/142022_navigation_test_fig8/Data.lsf


### PR DESCRIPTION
…Entity for a given IMC message.

* All messages added to `Filter By Entities` will only be replayed if coming from the provided source entity.
* Messages are only effectively filtered out after `Seconds to skip`.
* Small modernization (`0` -> `nullptr; `typedef` -> `using`)
* Fixed major memory leak. During main deserialization we were not cleaning up memory.