### PR TITLE
Fix compilation on OpenBSD

### DIFF
--- a/src/DUNE/Hardware/SocketCAN.hpp
+++ b/src/DUNE/Hardware/SocketCAN.hpp
@@ -91,7 +91,7 @@ namespace DUNE
       IO::NativeHandle
       doGetNative(void) const
       {
-#if defined(DUNE_OS_LINUX)
+#if defined(DUNE_OS_LINUX) || defined(DUNE_OS_OPENBSD)
         return m_can_socket; // Makes Poll::poll work
 #else
         return nullptr;


### PR DESCRIPTION
I had to make this change to get DUNE to compile on OpenBSD. Perhaps you'd like to merge it.

On a related note, I had to run CMake as follows (OpenBSD libraries are installed under `/usr/local/lib`):

```
mkdir build && cd build && CXXFLAGS="-L/usr/local/lib" cmake ..
```

Otherwise, I would get the following error:

```
ld: error: unable to find library -lcurl
```

Not sure where I'd patch this in the CMake files.