### PR TITLE
DUNE/Utils/String: fix rightTrimInPlace underflow on empty/all-ws input

### DIFF
--- a/src/DUNE/Utils/String.cpp
+++ b/src/DUNE/Utils/String.cpp
@@ -82,9 +82,12 @@ namespace DUNE
     void
     String::rightTrimInPlace(char* str)
     {
-      char* r = str + std::strlen(str) - 1; // Rightmost character
+      size_t len = std::strlen(str);
+      if (len == 0)
+        return;
 
-      for (; isspace(*r); --r)
+      char* r = str + len - 1; // Rightmost character
+      for (; r >= str && isspace(static_cast<unsigned char>(*r)); --r)
         *r = 0;
     }
 


### PR DESCRIPTION
See #290 