### PR TITLE
vendor: ais: Fix missing header

### DIFF
--- a/vendor/libraries/ais/vdm.h
+++ b/vendor/libraries/ais/vdm.h
@@ -67,6 +67,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 // #include "base/logging.h"
 #include "ais.h"


### PR DESCRIPTION
When compiling with newer versions g++ (gcc version 16.1.1), it  complains about unknown `uint8_t`  due to missing header. This PR fixes it.
